### PR TITLE
feat(cli): add session count to golembot status

### DIFF
--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, readFile, mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { loadSession, saveSession, clearSession, pruneExpiredSessions, appendHistory, getHistoryPath } from '../session.js';
+import { loadSession, saveSession, clearSession, pruneExpiredSessions, appendHistory, getHistoryPath, countSessions } from '../session.js';
 
 describe('session', () => {
   let dir: string;
@@ -220,6 +220,27 @@ describe('session', () => {
       // Verify final state
       expect(await loadSession(dir, 'user:a')).toBe('a-2');
       expect(await loadSession(dir, 'user:c')).toBe('c-1');
+    });
+  });
+
+  describe('countSessions', () => {
+    it('returns 0 when no sessions exist', async () => {
+      expect(await countSessions(dir)).toBe(0);
+    });
+
+    it('counts saved sessions', async () => {
+      await saveSession(dir, 'sess-1', 'user:a');
+      await saveSession(dir, 'sess-2', 'user:b');
+      await saveSession(dir, 'sess-3', 'user:c');
+      expect(await countSessions(dir)).toBe(3);
+    });
+
+    it('reflects cleared sessions', async () => {
+      await saveSession(dir, 'sess-1', 'user:a');
+      await saveSession(dir, 'sess-2', 'user:b');
+      expect(await countSessions(dir)).toBe(2);
+      await clearSession(dir, 'user:a');
+      expect(await countSessions(dir)).toBe(1);
     });
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -401,9 +401,11 @@ program
   .action(async (opts: { dir: string; json?: boolean }) => {
     const dir = resolve(opts.dir);
     const { loadConfig, scanSkills } = await import('./workspace.js');
+    const { countSessions } = await import('./session.js');
     try {
       const config = await loadConfig(dir);
       const skills = await scanSkills(dir);
+      const sessionCount = await countSessions(dir);
       const channelNames = config.channels ? Object.keys(config.channels).filter(k => !!(config.channels as any)[k]) : [];
 
       if (opts.json) {
@@ -412,6 +414,7 @@ program
           engine: config.engine,
           model: config.model ?? null,
           skills: skills.map(s => ({ name: s.name, description: s.description })),
+          sessions: sessionCount,
           channels: channelNames,
           gateway: config.gateway ? { port: config.gateway.port ?? 3000, authEnabled: !!config.gateway.token } : null,
           directory: dir,
@@ -424,6 +427,7 @@ program
       console.log(`   Engine:     ${config.engine}`);
       if (config.model) console.log(`   Model:      ${config.model}`);
       console.log(`   Skills:     ${skills.length > 0 ? skills.map(s => s.name).join(', ') : '(none)'}`);
+      console.log(`   Sessions:   ${sessionCount}`);
       console.log(`   Channels:   ${channelNames.length > 0 ? channelNames.join(', ') : '(none)'}`);
       if (config.gateway) {
         const gw = config.gateway;

--- a/src/session.ts
+++ b/src/session.ts
@@ -108,6 +108,11 @@ export async function pruneExpiredSessions(dir: string, maxAgeDays: number): Pro
   if (changed) await writeStore(dir, store);
 }
 
+export async function countSessions(dir: string): Promise<number> {
+  const store = await readStore(dir);
+  return Object.keys(store).length;
+}
+
 export async function appendHistory(dir: string, entry: HistoryEntry): Promise<void> {
   const path = historyPath(dir, entry.sessionKey);
   const line = JSON.stringify(entry) + '\n';


### PR DESCRIPTION
## Summary

Adds the **session count** to the `golembot status` command, completing the last remaining piece of the **P2: `golembot status`** TODO from `docs/todo/enhancements.md`.

The `status` command already displayed name, engine, model, skills, channels, gateway, and directory. This PR adds `Sessions: N` to both human-readable and JSON output.

## Changes

| File | Change |
|------|--------|
| `src/session.ts` | Export `countSessions(dir)` — reads session store and returns key count |
| `src/cli.ts` | `status` command imports and displays session count (human + `--json`) |
| `src/__tests__/session.test.ts` | 3 new unit tests for `countSessions` |

## Example output

```
🤖 GolemBot Assistant Status

   Name:       my-assistant
   Engine:     cursor
   Model:      claude-sonnet-4-5
   Skills:     general, devops
   Sessions:   3
   Channels:   slack, discord
   Gateway:    port 3000, auth enabled
   Directory:  /home/user/my-bot
```

JSON (`--json`):
```json
{
  "name": "my-assistant",
  "engine": "cursor",
  "sessions": 3,
  ...
}
```

## Tests

All 25 session tests pass (3 new for `countSessions`).