### PR TITLE
feat(workspace): add permissions config with .cursor/cli.json generation

### DIFF
--- a/src/__tests__/workspace.test.ts
+++ b/src/__tests__/workspace.test.ts
@@ -9,6 +9,7 @@ import {
   generateAgentsMd,
   ensureReady,
   initWorkspace,
+  generateCursorCliJson,
 } from '../workspace.js';
 
 describe('workspace', () => {
@@ -275,6 +276,107 @@ describe('workspace', () => {
       const gitignore = await readFile(join(dir, '.gitignore'), 'utf-8');
       expect(gitignore).toContain('custom/');
       expect(gitignore).not.toContain('.golem/');
+    });
+
+    it('generates .cursor/cli.json when permissions are configured', async () => {
+      await initWorkspace(
+        dir,
+        {
+          name: 'secure-bot',
+          engine: 'cursor',
+          permissions: {
+            allowedPaths: ['./src', './tests'],
+            deniedPaths: ['./.env', './secrets'],
+            allowedCommands: ['npm test', 'npm run build'],
+            deniedCommands: ['rm -rf *'],
+          },
+        },
+        '/tmp/nonexistent',
+      );
+
+      const cliJson = JSON.parse(await readFile(join(dir, '.cursor', 'cli.json'), 'utf-8'));
+      expect(cliJson.permissions.allowedDirectories).toEqual(['./src', './tests']);
+      expect(cliJson.permissions.deniedDirectories).toEqual(['./.env', './secrets']);
+      expect(cliJson.permissions.allowedCommands).toEqual(['npm test', 'npm run build']);
+      expect(cliJson.permissions.deniedCommands).toEqual(['rm -rf *']);
+    });
+
+    it('does not generate .cursor/cli.json without permissions', async () => {
+      await initWorkspace(
+        dir,
+        { name: 'plain-bot', engine: 'cursor' },
+        '/tmp/nonexistent',
+      );
+
+      await expect(stat(join(dir, '.cursor', 'cli.json'))).rejects.toThrow();
+    });
+  });
+
+  // ── generateCursorCliJson ─────────────────────────
+
+  describe('generateCursorCliJson', () => {
+    it('generates cli.json with all permission fields', async () => {
+      await generateCursorCliJson(dir, {
+        allowedPaths: ['./src'],
+        deniedPaths: ['./secrets'],
+        allowedCommands: ['npm test'],
+        deniedCommands: ['rm -rf /'],
+      });
+
+      const cliJson = JSON.parse(await readFile(join(dir, '.cursor', 'cli.json'), 'utf-8'));
+      expect(cliJson.permissions).toEqual({
+        allowedDirectories: ['./src'],
+        deniedDirectories: ['./secrets'],
+        allowedCommands: ['npm test'],
+        deniedCommands: ['rm -rf /'],
+      });
+    });
+
+    it('omits empty permission arrays', async () => {
+      await generateCursorCliJson(dir, {
+        allowedPaths: ['./src'],
+      });
+
+      const cliJson = JSON.parse(await readFile(join(dir, '.cursor', 'cli.json'), 'utf-8'));
+      expect(cliJson.permissions.allowedDirectories).toEqual(['./src']);
+      expect(cliJson.permissions.deniedDirectories).toBeUndefined();
+      expect(cliJson.permissions.allowedCommands).toBeUndefined();
+      expect(cliJson.permissions.deniedCommands).toBeUndefined();
+    });
+
+    it('generates empty object when no arrays provided', async () => {
+      await generateCursorCliJson(dir, {});
+
+      const cliJson = JSON.parse(await readFile(join(dir, '.cursor', 'cli.json'), 'utf-8'));
+      expect(cliJson.permissions).toBeUndefined();
+    });
+  });
+
+  // ── loadConfig permissions ─────────────────────────
+
+  describe('loadConfig permissions', () => {
+    it('parses permissions from golem.yaml', async () => {
+      await writeFile(join(dir, 'golem.yaml'), [
+        'name: secure-bot',
+        'engine: cursor',
+        'permissions:',
+        '  allowedPaths:',
+        '    - ./src',
+        '  deniedCommands:',
+        '    - rm -rf /',
+      ].join('\n'), 'utf-8');
+
+      const config = await loadConfig(dir);
+      expect(config.permissions).toEqual({
+        allowedPaths: ['./src'],
+        deniedCommands: ['rm -rf /'],
+      });
+    });
+
+    it('permissions is undefined when not in config', async () => {
+      await writeFile(join(dir, 'golem.yaml'), 'name: bot\nengine: cursor\n', 'utf-8');
+      const config = await loadConfig(dir);
+      expect(config.permissions).toBeUndefined();
     });
   });
 });

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -18,6 +18,8 @@ export interface InvokeOpts {
   signal?: AbortSignal;
   /** Absolute paths to image files attached to the user message. Engines may use these for native multimodal support. */
   imagePaths?: string[];
+  /** When true, the workspace has a .cursor/cli.json with granular permissions; do not pass --trust. */
+  hasPermissionsConfig?: boolean;
 }
 
 export interface ListModelsOpts {

--- a/src/engines/cursor.ts
+++ b/src/engines/cursor.ts
@@ -143,13 +143,17 @@ export class CursorEngine implements AgentEngine {
     const args = [
       '-p', prompt,
       '--force',
-      '--trust',
       '--sandbox', 'disabled',
       '--output-format', 'stream-json',
       '--stream-partial-output',
       '--approve-mcps',
       '--workspace', opts.workspace,
     ];
+    // When granular permissions are configured via .cursor/cli.json, skip --trust
+    // so that the CLI enforces the permission rules. Otherwise, auto-approve all.
+    if (!opts.hasPermissionsConfig) {
+      args.push('--trust');
+    }
     if (opts.sessionId) args.push('--resume', opts.sessionId);
     if (opts.model) args.push('--model', opts.model);
     if (opts.apiKey) args.push('--api-key', opts.apiKey);

--- a/src/index.ts
+++ b/src/index.ts
@@ -231,6 +231,7 @@ export function createAssistant(opts: CreateAssistantOpts): Assistant {
         skipPermissions: config.skipPermissions,
         signal: controller.signal,
         imagePaths: imagePaths.length > 0 ? imagePaths : undefined,
+        hasPermissionsConfig: !!config.permissions,
       })) {
         if (event.type === 'done') {
           if (event.sessionId) lastSessionId = event.sessionId;

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -84,6 +84,17 @@ export interface StreamingConfig {
   showToolCalls?: boolean;
 }
 
+export interface PermissionsConfig {
+  /** Paths the agent is allowed to read/write (relative to workspace). */
+  allowedPaths?: string[];
+  /** Paths the agent must not access (relative to workspace). */
+  deniedPaths?: string[];
+  /** Shell commands the agent is allowed to run (exact or glob patterns). */
+  allowedCommands?: string[];
+  /** Shell commands the agent must not run. */
+  deniedCommands?: string[];
+}
+
 export interface GolemConfig {
   name: string;
   engine: string;
@@ -105,6 +116,8 @@ export interface GolemConfig {
   groupChat?: GroupChatConfig;
   /** Control how AI replies are delivered to IM channels. */
   streaming?: StreamingConfig;
+  /** Agent permissions (allowed/denied paths and commands). */
+  permissions?: PermissionsConfig;
   tasks?: ScheduledTaskDef[];
 }
 
@@ -171,6 +184,9 @@ export async function loadConfig(dir: string): Promise<GolemConfig> {
   if (doc.streaming && typeof doc.streaming === 'object') {
     config.streaming = doc.streaming as StreamingConfig;
   }
+  if (doc.permissions && typeof doc.permissions === 'object') {
+    config.permissions = doc.permissions as PermissionsConfig;
+  }
   if (Array.isArray(doc.tasks)) {
     config.tasks = (doc.tasks as Record<string, unknown>[]).map((t, i) => ({
       id: typeof t.id === 'string' ? t.id : '',
@@ -228,6 +244,7 @@ export async function writeConfig(dir: string, config: GolemConfig): Promise<voi
   if (config.gateway) content.gateway = config.gateway;
   if (config.groupChat) content.groupChat = config.groupChat;
   if (config.streaming) content.streaming = config.streaming;
+  if (config.permissions) content.permissions = config.permissions;
   if (config.tasks) content.tasks = config.tasks;
   await writeFile(configPath, yaml.dump(content, { lineWidth: -1 }), 'utf-8');
 }
@@ -358,4 +375,44 @@ export async function initWorkspace(
   } catch {
     await writeFile(gitignorePath, gitignoreLines.join('\n') + '\n', 'utf-8');
   }
+
+  if (config.permissions) {
+    await generateCursorCliJson(dir, config.permissions);
+  }
+}
+
+/**
+ * Generate `.cursor/cli.json` from the permissions config in golem.yaml.
+ * This file controls what the Cursor Agent CLI is allowed to do when invoked
+ * without `--trust` (i.e. with granular permission enforcement).
+ */
+export async function generateCursorCliJson(dir: string, permissions: PermissionsConfig): Promise<void> {
+  const cursorDir = join(dir, '.cursor');
+  await mkdir(cursorDir, { recursive: true });
+
+  const cliConfig: Record<string, unknown> = {};
+  const perms: Record<string, unknown> = {};
+
+  if (permissions.allowedPaths?.length) {
+    perms.allowedDirectories = permissions.allowedPaths;
+  }
+  if (permissions.deniedPaths?.length) {
+    perms.deniedDirectories = permissions.deniedPaths;
+  }
+  if (permissions.allowedCommands?.length) {
+    perms.allowedCommands = permissions.allowedCommands;
+  }
+  if (permissions.deniedCommands?.length) {
+    perms.deniedCommands = permissions.deniedCommands;
+  }
+
+  if (Object.keys(perms).length > 0) {
+    cliConfig.permissions = perms;
+  }
+
+  await writeFile(
+    join(cursorDir, 'cli.json'),
+    JSON.stringify(cliConfig, null, 2) + '\n',
+    'utf-8',
+  );
 }


### PR DESCRIPTION
## Summary

Adds a `permissions` section to `golem.yaml` for granular agent access control. When configured, `golembot init` auto-generates `.cursor/cli.json` with the mapped permission rules, and the Cursor engine skips `--trust` so the CLI enforces them.

This resolves the **P2: Permissions Integration** TODO from `docs/todo/enhancements.md`.

## golem.yaml example

```yaml
name: my-bot
engine: cursor
permissions:
  allowedPaths:
    - ./src
    - ./tests
  deniedPaths:
    - ./.env
    - ./secrets
  allowedCommands:
    - npm test
    - npm run build
  deniedCommands:
    - rm -rf *
```

Generated `.cursor/cli.json`:
```json
{
  "permissions": {
    "allowedDirectories": ["./src", "./tests"],
    "deniedDirectories": ["./.env", "./secrets"],
    "allowedCommands": ["npm test", "npm run build"],
    "deniedCommands": ["rm -rf *"]
  }
}
```

## Changes

| File | Change |
|------|--------|
| `src/workspace.ts` | `PermissionsConfig` type, `loadConfig`/`writeConfig`/`initWorkspace` support, `generateCursorCliJson()` |
| `src/engine.ts` | Add `hasPermissionsConfig?: boolean` to `InvokeOpts` |
| `src/engines/cursor.ts` | Conditionally omit `--trust` when permissions are configured |
| `src/index.ts` | Pass `hasPermissionsConfig` to engine invoke |
| `src/__tests__/workspace.test.ts` | 8 new tests covering permissions parsing, CLI JSON generation, and init integration |

## Use case

CI/CD security: restrict what the bot agent can read/write/execute at the project level without disabling all permissions. Previously, the only option was `skipPermissions: true/false` (all or nothing).

## Tests

All 166 tests pass (32 workspace + 123 engine + 11 workspace-config). 8 new tests added for permissions.