### PR TITLE
docs(todo): mark fullText, status, and permissions as completed

### DIFF
--- a/docs/todo/bugs-and-debt.md
+++ b/docs/todo/bugs-and-debt.md
@@ -12,12 +12,13 @@
 - ~~**P1** StreamEvent `done` missing `durationMs`~~ → Fixed: extracted from `duration_ms` in result events; Claude Code additionally provides `costUsd` (`total_cost_usd`) and `numTurns` (`num_turns`)
 - ~~**P0** `--stream-partial-output` summary duplication~~ → Fixed: CursorEngine layer accumulates text and compares to deduplicate
 
-### P2: `result.result` Field Not Exposed
+### ~~P2: `result.result` Field Not Exposed~~ ✅ Completed
 
-- **File**: `src/engine.ts` parseStreamLine
-- **Current state**: Successful result events have a `result` field (concatenation of all assistant text), but GolemBot only extracts `session_id`
-- **Impact**: If callers need the final complete reply text (without concatenating text deltas themselves), it's currently not possible
-- **Proposal**: Add `fullText?: string` to the `done` event
+- ~~**File**: `src/engine.ts` parseStreamLine~~
+- ~~**Current state**: Successful result events have a `result` field (concatenation of all assistant text), but GolemBot only extracts `session_id`~~
+- ~~**Impact**: If callers need the final complete reply text (without concatenating text deltas themselves), it's currently not possible~~
+- ~~**Proposal**: Add `fullText?: string` to the `done` event~~
+- Added `fullText?: string` to the `done` StreamEvent type; Cursor and Claude Code engines now extract `obj.result` into `fullText` on non-error result events
 
 ### P2: `user` Event Type Ignored
 
@@ -26,9 +27,10 @@
 - **Impact**: No functional impact, but documented here to avoid future confusion
 - **Proposal**: Keep ignoring — no action needed
 
-### P2: Permissions Not Utilized
+### ~~P2: Permissions Not Utilized~~ ✅ Completed
 
-- **File**: N/A
-- **Current state**: Cursor supports project-level permissions via `.cursor/cli.json` (Shell/Read/Write/WebFetch/Mcp), but GolemBot does not leverage this
-- **Impact**: Cannot provide fine-grained control for security-sensitive scenarios (e.g., a CI/CD bot that should not have write permissions)
-- **Proposal**: Add optional permissions config in `golem.yaml`, generate `.cursor/cli.json` during `init`
+- ~~**File**: N/A~~
+- ~~**Current state**: Cursor supports project-level permissions via `.cursor/cli.json` (Shell/Read/Write/WebFetch/Mcp), but GolemBot does not leverage this~~
+- ~~**Impact**: Cannot provide fine-grained control for security-sensitive scenarios (e.g., a CI/CD bot that should not have write permissions)~~
+- ~~**Proposal**: Add optional permissions config in `golem.yaml`, generate `.cursor/cli.json` during `init`~~
+- Added `PermissionsConfig` to `golem.yaml` (allowedPaths/deniedPaths/allowedCommands/deniedCommands); `initWorkspace` generates `.cursor/cli.json`; CursorEngine skips `--trust` when permissions are configured

--- a/docs/todo/enhancements.md
+++ b/docs/todo/enhancements.md
@@ -18,11 +18,12 @@
 - CLI `run` mode displays duration in gray text
 - e2e verification: `collectChat()` returns `durationMs`, assertion `durationMs >= 0`
 
-### P2: Permissions Integration
+### ~~P2: Permissions Integration~~ ✅ Completed
 
-- Allow project-level permissions configuration via `golem.yaml`
-- Automatically generate `.cursor/cli.json` during `init`
-- Valuable for CI/CD security scenarios (restricting bot's file write scope, command execution scope)
+- ~~Allow project-level permissions configuration via `golem.yaml`~~
+- ~~Automatically generate `.cursor/cli.json` during `init`~~
+- ~~Valuable for CI/CD security scenarios (restricting bot's file write scope, command execution scope)~~
+- `PermissionsConfig` type added to `golem.yaml`; `initWorkspace` generates `.cursor/cli.json`; CursorEngine conditionally omits `--trust` when permissions are set
 
 ### P3: `/compress` Long Conversation Compression
 
@@ -50,10 +51,11 @@
 
 ## CLI Layer
 
-### P2: `golembot status`
+### ~~P2: `golembot status`~~ ✅ Completed
 
-- Display current assistant status: name, engine, installed skill list, active session count
-- Quickly understand the state of an assistant directory
+- ~~Display current assistant status: name, engine, installed skill list, active session count~~
+- ~~Quickly understand the state of an assistant directory~~
+- CLI `golembot status` shows name, engine, model, skills, session count, channels, gateway, and directory; supports `--json` for machine-readable output
 
 ### P3: `golembot log`
 


### PR DESCRIPTION
## Summary

Updates the TODO tracking documents to reflect the features completed in PRs #6, #7, and #8.

### Items marked as completed

| File | Item | Implemented in |
|------|------|---------------|
| `bugs-and-debt.md` | P2: `result.result` Field Not Exposed | PR #6 (`fullText` on done event) |
| `bugs-and-debt.md` | P2: Permissions Not Utilized | PR #8 (permissions config) |
| `enhancements.md` | P2: Permissions Integration | PR #8 (permissions config) |
| `enhancements.md` | P2: `golembot status` | PR #7 (session count in status) |

Each item now includes a brief completion note describing what was implemented.