### PR TITLE
docs(zh): translate reference/ and testing/ documentation

### DIFF
--- a/docs/zh/reference/architecture.md
+++ b/docs/zh/reference/architecture.md
@@ -1,0 +1,567 @@
+# GolemBot 架构设计
+
+> **为什么叫 "GolemBot"？** Golem（魔像）是传说中用泥土塑造的躯体——在上面写下真名（shem），它就会活过来。
+> 我们的项目也是同样的道理：将一个 Coding Agent 作为灵魂注入目录，它就变成了你的 AI 助手。
+
+> 本文档是 GolemBot 项目的核心架构参考。所有实现都应与本文档保持一致。
+> 当实现与架构产生冲突，或需要变更和优化时，**必须先更新本文档**，再修改代码。
+
+## 1. 产品定位
+
+**GolemBot 是一个本地优先的个人 AI 助手——它使用你已有的 Coding Agent 作为大脑，不仅能聊天，还能真正帮你做事。**
+
+使用场景与 OpenClaw 类似（个人助手、多频道接入、技能扩展），核心区别在于大脑：
+
+- OpenClaw：直接调用 LLM API + 自定义工具系统 → 大脑是无状态的 API
+- GolemBot：使用 Coding Agent CLI 作为引擎 → **大脑是一个有状态的、住在目录里的 Coding Agent**
+
+这带来了一个关键的体验差异：**OpenClaw 的助手是全局的，而 GolemBot 的助手是绑定到目录的。** 因为 Coding Agent 天然在目录中工作——技能、脚本、记忆和工作产物都在里面。
+
+独特优势：
+
+- **更强大**：Coding Agent 原生支持读写文件、运行代码、操作浏览器、多步推理
+- **引擎可选**：Cursor / Claude Code / OpenCode / Codex——用哪个随你
+- **完全透明**：`ls` 一下助手目录就能看到它知道什么、能做什么、做过什么
+- **可版本控制**：整个助手可以通过 git 管理、分享、克隆
+
+## 2. 核心理念
+
+**Coding Agent = 灵魂，GolemBot = 泥土之躯。**
+
+GolemBot 不实现 LLM 推理、工具调用、上下文管理。它只做三件事：
+
+1. 准备工作区（注入技能）
+2. 调用 Coding Agent CLI（传入用户消息）
+3. 将响应返回给用户
+
+所有复杂工作（决策、规划、执行）都委托给 Coding Agent。
+
+### 库优先，CLI 只是薄壳
+
+GolemBot 的核心是一个**可导入的 TypeScript 库**，而非 CLI 工具。CLI 只是这个库的一个消费者。
+
+```
+              golembot 核心库 (index.ts)
+             createAssistant() → Assistant
+            /        |         \         \
+       CLI 薄壳    库导入     HTTP       Bot
+      (cli.ts)  (第三方)    封装       封装
+                          (第三方)    (第三方)
+```
+
+所有调用方式共享相同的核心逻辑，零重复。这使得 GolemBot 易于**嵌入任何场景**，作为各种领域 Agent 方案的核心引擎。
+
+## 3. 两个核心概念
+
+整个框架只有两个概念——不多不少：
+
+### 1. 助手目录
+
+一个目录就是一个助手（一个 GolemBot）。目录结构：
+
+```
+~/my-assistant/
+├── golem.yaml             # 助手配置（只配引擎类型和名字）
+├── skills/                # 技能目录——里面有什么就加载什么
+│   ├── general/
+│   │   └── SKILL.md       # 通用助手技能
+│   └── ops-xhs/
+│       ├── SKILL.md       # 小红书运营技能
+│       ├── xhs.py         # 技能附带的脚本
+│       └── brand-voice.md # 辅助知识文档
+├── AGENTS.md              # Golem 自动生成的上下文文档
+├── .golem/                # 内部状态（会话等，gitignore）
+└── ...                    # Agent 工作过程中产生的文件（笔记、数据、报告等）
+```
+
+配置文件 `golem.yaml` 很精简——只配引擎，不配技能：
+
+```yaml
+name: my-assistant
+engine: cursor              # cursor | claude-code | opencode | codex
+model: claude-sonnet        # 可选，首选模型
+
+# 可选：IM 频道配置（gateway 会连接所有已配置的频道）
+channels:
+  feishu:
+    appId: ${FEISHU_APP_ID}
+    appSecret: ${FEISHU_APP_SECRET}
+  dingtalk:
+    clientId: ${DINGTALK_CLIENT_ID}
+    clientSecret: ${DINGTALK_CLIENT_SECRET}
+
+# 可选：网关服务配置
+gateway:
+  port: 3000
+  token: ${GOLEM_TOKEN}
+```
+
+敏感字段支持 `${ENV_VAR}` 占位符引用环境变量（由 `resolveEnvPlaceholders()` 在加载时解析）。`channels` 和 `gateway` 都是可选的——不配置时行为与纯 CLI 模式完全一致。
+
+**技能不在配置文件中声明。** `skills/` 目录是唯一的事实来源——里面有什么技能，助手就具备什么能力。想加技能？把文件夹放进去。想删？把文件夹删掉。`ls skills/` 就能看到助手的完整能力集。
+
+### 2. 技能
+
+技能是助手能力的载体。一个技能就是一个目录，包含：
+
+- `SKILL.md`：知识和指令（必须）
+- 其他辅助文件：知识文档、脚本、配置模板等（可选）
+
+格式完全兼容 Cursor 的 `.cursor/skills/`、Claude Code 的 `.claude/skills/`，以及 OpenClaw 的 `SKILL.md`。
+
+**没有独立的 Tool 概念。** 脚本直接放在技能目录中，`SKILL.md` 描述如何调用它们。Coding Agent 原生就能执行任何脚本——不需要框架层面的"注册"。
+
+## 4. 使用方式
+
+所有方式内部共享相同的核心逻辑（`createAssistant` → `assistant.chat()`）。
+
+### 方式一：CLI（最快上手）
+
+```bash
+npm install -g golembot
+
+mkdir ~/my-assistant && cd ~/my-assistant
+golembot init         # 交互式：选引擎、起名字、生成配置、拷贝默认技能
+golembot run          # REPL 对话
+```
+
+想加技能？直接把技能文件夹放到 `skills/` 目录下——不需要任何命令。
+
+### 方式二：库导入（开发者嵌入）
+
+```typescript
+import { createAssistant } from 'golembot';
+
+const assistant = createAssistant({ dir: './my-agent' });
+
+for await (const event of assistant.chat('分析竞品数据')) {
+  if (event.type === 'text') process.stdout.write(event.content);
+}
+```
+
+### 方式三：嵌入各种场景
+
+Slack Bot：
+
+```typescript
+import { createAssistant } from 'golembot';
+const assistant = createAssistant({ dir: './slack-agent' });
+
+slackApp.message(async ({ message, say }) => {
+  let reply = '';
+  for await (const event of assistant.chat(message.text)) {
+    if (event.type === 'text') reply += event.content;
+  }
+  await say(reply);
+});
+```
+
+HTTP API：
+
+```typescript
+import { createAssistant } from 'golembot';
+const agent = createAssistant({ dir: './api-agent' });
+
+app.post('/api/chat', async (req, res) => {
+  for await (const event of agent.chat(req.body.message)) {
+    res.write(JSON.stringify(event) + '\n');
+  }
+  res.end();
+});
+```
+
+Electron 桌面应用、Telegram 机器人、cron 定时任务……都是同一个模式：创建助手 → 调用 chat() → 处理事件流。
+
+### 方式四：网关（IM + HTTP 统一服务）
+
+```bash
+golembot gateway              # 从 golem.yaml 读取频道配置，启动 IM 适配器 + HTTP 服务
+golembot gateway --port 3000  # 覆盖端口
+golembot gateway --verbose    # 详细日志
+```
+
+网关是一个**常驻服务**，内部复用 `createAssistant()` + `server.ts`，上面加了一层 IM 频道适配层。`golem.yaml` 中配了哪些频道，网关启动时就自动连接对应的 IM 平台：
+
+- **飞书（Lark）**：WebSocket 长连接模式（无需公网 IP）
+- **钉钉**：Stream 模式（WebSocket，无需公网 IP）
+- **企业微信**：Webhook 回调模式（需要公网 URL）
+
+IM 频道和 HTTP API 并行工作。一个频道崩溃不影响其他的。
+
+### 方式五：引导式配置向导
+
+```bash
+mkdir my-bot && cd my-bot
+golembot onboard
+```
+
+交互式引导配置（7 步）：选引擎 → 起名字 → 选 IM 频道 → 配频道凭据 → 选场景模板 → 生成配置 → 启动网关。自动生成 `golem.yaml`、`.env`、`.env.example` 和 `.gitignore`。
+
+## 5. 架构
+
+### 源文件结构
+
+核心与 CLI 分离：
+
+**核心库（可导入）：**
+
+- **`index.ts`** — 公共 API：`createAssistant(opts) → Assistant`。协调工作区、引擎和会话。包含并发锁：对于同一个助手实例和同一个 sessionKey，同时只能执行一个 `chat()`；不同 sessionKey 可以并行。
+- **`engine.ts`** — 引擎接口 + Cursor / Claude Code / OpenCode / Codex 四引擎实现。进程管理和技能注入是引擎内部细节。
+- **`workspace.ts`** — 读取 `golem.yaml`（包括 `channels` 和 `gateway` 字段），扫描 `skills/` 目录，自动生成 `AGENTS.md`。`resolveEnvPlaceholders()` 解析 `${ENV_VAR}` 占位符。
+- **`session.ts`** — 多用户会话存储：`.golem/sessions.json`，按 `sessionKey` 索引。
+- **`server.ts`** — HTTP 服务：`createServer(assistant, opts) → http.Server`。`POST /chat`（SSE）、`POST /reset`、`GET /health`。
+- **`channel.ts`** — `ChannelAdapter` 接口和 `ChannelMessage` 类型定义。`buildSessionKey()` 生成频道级会话 key，`stripMention()` 去除 @提及。
+- **`channels/feishu.ts`** — 飞书适配器（`@larksuiteoapi/node-sdk` WebSocket 长连接模式）。
+- **`channels/dingtalk.ts`** — 钉钉适配器（`dingtalk-stream` Stream 模式）。
+- **`channels/wecom.ts`** — 企业微信适配器（`@wecom/crypto` + `xml2js` Webhook 回调模式）。
+- **`gateway.ts`** — 网关常驻服务：读取 golem.yaml → 创建 Assistant → 启动 HTTP 服务 → 遍历频道配置启动适配器 → 将消息路由到 `assistant.chat()` → 回复。启动时自动注册到 Fleet 目录。
+- **`dashboard.ts`** — 网关 Dashboard：指标收集、SSE 广播、HTML 渲染（频道状态、统计、活动流、快速测试）。
+- **`ui-shared.ts`** — 共享 UI 常量（CSS、favicon、引擎配色、HTML 转义），供 Dashboard 和 Fleet 共用。
+- **`fleet.ts`** — Fleet 多 bot 管理：文件系统注册表（`~/.golembot/fleet/`）、PID 存活检测、Fleet Dashboard HTML 渲染、Fleet HTTP 服务。
+
+**CLI 薄壳：**
+
+- **`cli.ts`** — 命令入口：`init`、`run`、`serve`、`gateway`、`onboard`、`status`、`skill`、`fleet`。自动加载 `.env` 文件。
+- **`onboard.ts`** — 引导式配置向导（7 步交互）。生成 golem.yaml、.env、.env.example、.gitignore，可选安装场景模板。
+
+**IM SDK 依赖策略**：`@larksuiteoapi/node-sdk`、`dingtalk-stream`、`@wecom/crypto` 和 `xml2js` 都是可选的 peerDependencies。网关启动时动态导入对应 SDK，缺少时给出安装提示。
+
+### 核心 API
+
+```typescript
+export function createAssistant(opts: {
+  dir: string;           // 助手目录路径
+  engine?: string;       // 覆盖 golem.yaml 中的引擎配置
+  model?: string;        // 覆盖模型配置
+  apiKey?: string;       // Agent API key（Cursor: CURSOR_API_KEY, Claude Code: ANTHROPIC_API_KEY, OpenCode: 取决于提供商）
+}): Assistant;
+
+export interface Assistant {
+  chat(message: string, opts?: { sessionKey?: string }): AsyncIterable<StreamEvent>;
+  init(opts: { engine: string; name: string }): Promise<void>;
+  resetSession(sessionKey?: string): Promise<void>;
+}
+
+export type StreamEvent =
+  | { type: 'text'; content: string }
+  | { type: 'tool_call'; name: string; args: string }
+  | { type: 'tool_result'; content: string }
+  | { type: 'error'; message: string }
+  | { type: 'done'; sessionId?: string; durationMs?: number; costUsd?: number; numTurns?: number };
+```
+
+`costUsd` 和 `numTurns` 由 Claude Code 引擎提供；Cursor 引擎下为 `undefined`。
+
+API 极简：`createAssistant` + `chat` + `init` + `resetSession`——仅此而已。
+
+### 会话路由（sessionKey）
+
+`chat()` 接受可选的 `sessionKey` 参数，用于多用户场景下的会话隔离：
+
+```typescript
+// 单用户（Phase 1 模式，完全向后兼容）
+assistant.chat("你好")
+// 等价于 assistant.chat("你好", { sessionKey: "default" })
+
+// 多用户——每个用户获得独立的引擎会话
+assistant.chat("你好", { sessionKey: "feishu:user_123" })
+assistant.chat("查一下数据", { sessionKey: "slack:U456" })
+```
+
+存储结构变化：
+
+```json
+// Phase 1: .golem/sessions.json
+{ "engineSessionId": "abc-123" }
+
+// Phase 2: .golem/sessions.json
+{
+  "default": { "engineSessionId": "abc-123" },
+  "feishu:user_123": { "engineSessionId": "def-456" },
+  "slack:U456": { "engineSessionId": "ghi-789" }
+}
+```
+
+设计原则：
+- 默认 key 是 `"default"`——单用户场景无需感知 sessionKey
+- 不同的 sessionKey 映射到不同的引擎会话，但**共享相同的技能和工作目录**
+- 锁粒度从"一把全局锁"变为**按 sessionKey 加锁**：相同 key 排队，不同 key 并行
+- `resetSession(key?)` 清除指定 key 的会话；省略则清除 `"default"`
+
+### HTTP 服务（`golembot serve`）
+
+内置轻量 HTTP 服务，可让任何 IM webhook 接入：
+
+```bash
+golembot serve --port 3000 --token my-secret
+```
+
+**接口设计：**
+
+```
+POST /chat
+  Headers: Authorization: Bearer <token>
+  Body: { "message": "你好", "sessionKey": "feishu:user_123" }
+  Response: text/event-stream (SSE)
+    data: {"type":"text","content":"你好"}
+    data: {"type":"tool_call","name":"readFile","args":"{}"}
+    data: {"type":"done","sessionId":"xxx"}
+
+POST /reset
+  Headers: Authorization: Bearer <token>
+  Body: { "sessionKey": "feishu:user_123" }
+  Response: 200 { "ok": true }
+
+GET /health
+  Response: 200 { "status": "ok", "name": "my-assistant" }
+```
+
+**设计原则：**
+- 使用 Node.js 内置 `node:http`，零额外依赖
+- SSE 协议（`text/event-stream`），所有语言/平台都能消费
+- Bearer token 认证（`--token` 参数或 `GOLEM_TOKEN` 环境变量）
+- `server.ts` 导出 `createServer()` 工厂函数，CLI 和第三方都能使用
+
+**接入 IM 的典型流程：**
+
+```
+飞书 webhook → 你的 3 行转发脚本 → POST localhost:3000/chat → SSE → 推回飞书
+Slack event  → 你的 3 行转发脚本 → POST localhost:3000/chat → SSE → 推回 Slack
+```
+
+**也可以直接导入库（不走 HTTP）：**
+
+```typescript
+import { createAssistant } from 'golembot';
+const bot = createAssistant({ dir: './my-bot' });
+
+slackApp.message(async ({ message, say }) => {
+  let reply = '';
+  for await (const ev of bot.chat(message.text, { sessionKey: `slack:${message.user}` })) {
+    if (ev.type === 'text') reply += ev.content;
+  }
+  await say(reply);
+});
+```
+
+### `init` 工作流
+
+```
+golembot init（或 assistant.init()）
+1. 检查目录是否已有 golem.yaml → 有则报错
+2. 交互提示：引擎类型（cursor/claude-code/opencode）、助手名称
+3. 创建 golem.yaml
+4. 创建 skills/ 目录
+5. 将内置技能拷贝到 skills/（general + im-adapter）
+6. 创建 .golem/ 目录（内部状态）
+7. 生成 AGENTS.md
+8. 生成 .gitignore（忽略 .golem/）
+```
+
+### 网关工作流
+
+```
+golembot gateway
+1. 自动加载 .env（在 CLI 入口层）
+2. 读取 golem.yaml（channels + gateway 配置）
+3. resolveEnvPlaceholders() 解析 ${ENV_VAR} 占位符
+4. 创建 Assistant 实例
+5. 启动 HTTP 服务（Dashboard 位于 GET /，/api/status、/api/events 端点）
+6. 遍历频道配置，动态导入并启动对应适配器
+7. 注册到 Fleet 目录（~/.golembot/fleet/<name>-<port>.json）
+8. 适配器收到消息 → buildSessionKey() → stripMention() → assistant.chat() → 回复
+9. 流式响应拼接为完整文本后一次性发送（IM 平台不支持流式）
+10. SIGINT/SIGTERM → 从 Fleet 注销 → 优雅关闭所有适配器和 HTTP 服务
+```
+
+### 数据流：一轮对话
+
+无论通过 CLI 还是库导入调用，内部流程完全一致：
+
+```
+调用方 → assistant.chat(message)
+  → index.ts: 获取并发锁
+  → workspace.ts: ensureReady() — 扫描 skills/ + 生成 AGENTS.md
+  → engine.ts: invoke(message, skillList, sessionId?)
+    → 注入技能：
+        Cursor    → .cursor/skills/ 软链接
+        Claude    → .claude/skills/ 软链接 + CLAUDE.md
+        OpenCode  → .opencode/skills/ 软链接 + opencode.json
+    → 启动 Agent 进程：
+        Cursor    → child_process.spawn
+        Claude    → child_process.spawn
+        OpenCode  → child_process.spawn
+    → 逐行解析输出 → yield StreamEvent
+  → index.ts: 保存会话 + 释放锁
+  → 调用方收到 StreamEvent 流
+```
+
+### AGENTS.md 自动生成
+
+`workspace.ts` 在每次 `ensureReady()` 调用时，基于扫描 `skills/` 目录，在助手目录中自动生成 `AGENTS.md`（注意：是在助手目录中，不是本项目的）：
+
+```markdown
+# Assistant Context
+
+## Installed Skills
+- general: 通用个人助手能力
+- ops-xhs: 小红书运营助手（包含 xhs.py 脚本）
+
+## Directory Structure
+- skills/ — 技能目录（每个子目录是一个技能，包含 SKILL.md 和可选脚本）
+- AGENTS.md — 本文件，由 GolemBot 自动生成
+
+## Conventions
+- 需要持久记住的信息应写入 notes.md
+- 生成的报告/文件放入对应目录
+```
+
+这让 Coding Agent 一启动就能理解自己的环境和能力。
+
+## 6. 多轮交互
+
+- **引擎原生优先**：多轮上下文依赖 Coding Agent CLI 的原生会话机制（Cursor 和 Claude Code 都支持 `--resume`）
+- **不支持 resume 的引擎按单轮处理**：工作区中的文件是唯一的跨轮记忆
+- **无 TTL**：GolemBot 不主动过期会话；引擎自行管理会话生命周期
+- **resume 失败自动回退**：如果引擎的 `--resume` 失败（引擎侧过期/损坏），自动启动新会话，对用户透明
+- **手动重置**：用户可通过 `/reset`（CLI）或 `assistant.resetSession()`（API）显式清除会话
+- **会话存储**：`.golem/sessions.json`，仅存储 `{ engineSessionId }`
+
+## 7. 引擎接口
+
+```typescript
+interface AgentEngine {
+  invoke(prompt: string, opts: {
+    workspace: string;       // 助手目录路径
+    skillPaths: string[];    // skills/ 下技能目录的绝对路径
+    sessionId?: string;
+    model?: string;
+  }): AsyncIterable<StreamEvent>;
+}
+
+type StreamEvent =
+  | { type: 'text'; content: string }
+  | { type: 'tool_call'; name: string; args: string }
+  | { type: 'tool_result'; content: string }
+  | { type: 'error'; message: string }
+  | { type: 'done'; sessionId?: string; durationMs?: number; costUsd?: number; numTurns?: number };
+```
+
+四个引擎实现，通过 `createEngine(type)` 工厂函数创建：
+
+**CursorEngine** — 通过 child_process.spawn 调用 `agent` CLI：
+
+```typescript
+class CursorEngine implements AgentEngine {
+  async *invoke(prompt, opts) {
+    // 1. 注入技能：将 skillPaths 软链接到 .cursor/skills/
+    // 2. spawn: agent -p <prompt> --output-format stream-json --stream-partial-output ...
+    // 3. stripAnsi + 逐行解析 stream-json → yield StreamEvent
+    // 4. segmentAccum 去重（Cursor 的摘要事件）
+  }
+}
+```
+
+**ClaudeCodeEngine** — 通过 child_process.spawn 调用 `claude` CLI：
+
+```typescript
+class ClaudeCodeEngine implements AgentEngine {
+  async *invoke(prompt, opts) {
+    // 1. 注入技能：将 skillPaths 软链接到 .claude/skills/ + 生成 CLAUDE.md
+    // 2. spawn: claude -p <prompt> --output-format stream-json --verbose --dangerously-skip-permissions ...
+    // 3. 逐行解析 stream-json → parseClaudeStreamLine() → yield StreamEvent[]
+    // 4. 不需要 ANSI 清理或去重
+  }
+}
+```
+
+**OpenCodeEngine** — 通过 child_process.spawn 调用 `opencode` CLI：
+
+```typescript
+class OpenCodeEngine implements AgentEngine {
+  async *invoke(prompt, opts) {
+    // 1. 注入技能：将 skillPaths 软链接到 .opencode/skills/
+    // 2. 生成/更新 opencode.json（权限配置 + 模型配置）
+    // 3. spawn: opencode run "prompt" --format json [--model provider/model] [--session ses_xxx]
+    // 4. 逐行解析 NDJSON → parseOpenCodeStreamLine() → yield StreamEvent[]
+    // 5. 多提供商 API Key 通过 resolveOpenCodeEnv() 推断
+  }
+}
+```
+
+四个引擎的关键差异：
+
+| | CursorEngine | ClaudeCodeEngine | OpenCodeEngine | CodexEngine |
+|---|---|---|---|---|
+| 启动方式 | child_process.spawn | child_process.spawn | child_process.spawn | child_process.spawn |
+| 输出格式 | stream-json（带 ANSI） | stream-json（纯 JSON） | NDJSON（`--format json`） | JSON（`--json`） |
+| 技能注入 | `.cursor/skills/` 软链接 | `.claude/skills/` + CLAUDE.md | `.opencode/skills/` + opencode.json | N/A（prompt 注入） |
+| 会话恢复 | `--resume <uuid>` | `--resume <uuid>` | `--session <ses_xxx>` | `exec resume <thread_id>` |
+| API Key | CURSOR_API_KEY | ANTHROPIC_API_KEY | 取决于提供商 | CODEX_API_KEY |
+| 权限绕过 | `--force --trust --sandbox disabled` | `--dangerously-skip-permissions` | opencode.json permission | `--full-auto` |
+
+但对外暴露的 `StreamEvent` 完全一致。
+
+## 8. 关键设计决策
+
+1. **库优先，CLI 是薄壳**：核心是可导入的库（`createAssistant`）；CLI 只是一个消费者。这使得 GolemBot 可嵌入任何场景。
+2. **目录即助手**：助手住在目录里，目录是唯一的事实来源。Coding Agent 天然在目录中工作——这是与 OpenClaw（全局配置）的刻意差异。
+3. **目录即技能列表**：`skills/` 里有什么就加载什么——技能不在配置文件中声明，消除配置与现实的不一致。
+4. **只有两个概念**：助手目录 + 技能。没有 Tools、没有 Blueprints、没有 Registry。
+5. **技能即能力**：知识（Markdown）和工具（脚本）都在技能目录中，不分开。Coding Agent 原生能执行脚本——不需要框架"注册"。
+6. **技能注入是引擎的责任**：每个引擎自行决定如何注入技能（Cursor → `.cursor/skills/` 软链接，Claude Code → `.claude/skills/` 软链接 + `CLAUDE.md`，OpenCode → `.opencode/skills/` 软链接 + `opencode.json`）——核心层不关心。
+7. **不做 Agent 该做的事**：不做上下文管理、不做工具调度、不做决策、不做会话 TTL。一切委托给 Coding Agent。
+8. **并发安全**：同一个助手实例在任意时刻只允许执行一个 `chat()`，防止多个请求同时操作工作区。
+9. **TypeScript**：成熟的频道生态（Telegram/Slack/Discord），且子进程调用与语言无关。
+
+## 9. 演进路线
+
+**Phase 1 — CLI 助手（当前）**
+
+- `golembot init` + `golembot run` 两个命令
+- Cursor 引擎（child_process.spawn + 技能注入）
+- 技能目录扫描
+- 会话管理（resume + 自动回退）
+- 并发锁
+- 4 个核心源文件 + 1 个 CLI 薄壳
+
+**Phase 2 — 多用户 + HTTP 服务（当前）**
+
+- 会话路由：`chat(msg, { sessionKey })` 支持多用户隔离
+- 并发锁按 sessionKey 隔离：不同用户可并行
+- `server.ts`：内置 HTTP 服务 + SSE 流式响应 + Bearer token 认证
+- `golembot serve` CLI 命令
+- 会话存储升级为按 key 索引的多用户结构
+
+**Phase 3 — 多引擎** ✅
+
+- ~~Claude Code 引擎~~ ✅（`ClaudeCodeEngine`，stream-json 解析，原生 `.claude/skills/` 注入）
+- ~~OpenCode 引擎~~ ✅（`OpenCodeEngine`，NDJSON 解析，`.opencode/skills/` 注入，多提供商 API Key，`opencode.json` 权限配置）
+- ~~Codex 引擎~~ ✅（`CodexEngine`，JSON 解析，`exec`/`exec resume` 子命令，`CODEX_API_KEY`）
+
+**Phase 4 — 网关 + IM 频道** ✅
+
+- ~~`ChannelAdapter` 接口 + `ChannelMessage` 类型~~ ✅
+- ~~飞书适配器（WebSocket 长连接，`@larksuiteoapi/node-sdk`）~~ ✅
+- ~~钉钉适配器（Stream，`dingtalk-stream`）~~ ✅
+- ~~企业微信适配器（Webhook，`@wecom/crypto`）~~ ✅
+- ~~网关常驻服务（`golembot gateway`）~~ ✅
+- ~~`golem.yaml` 扩展 `channels` + `gateway` 字段~~ ✅
+- ~~`${ENV_VAR}` 占位符解析~~ ✅
+- ~~CLI `.env` 自动加载~~ ✅
+
+**Phase 5 — 开箱即用** ✅
+
+- ~~引导式配置向导（`golembot onboard`，7 步交互）~~ ✅
+- ~~内置技能：`general`（增强版，含持久记忆约定）+ `im-adapter`（IM 回复约定）~~ ✅
+- ~~模板系统（6 个场景模板：customer-support、data-analyst、code-reviewer、ops-assistant、meeting-notes、research）~~ ✅
+- ~~Docker 部署（Dockerfile + docker-compose.yml）~~ ✅
+- ~~README.md + LICENSE + CONTRIBUTING.md~~ ✅
+
+**Phase 6 — 生态扩展**
+
+- ~~技能仓库（`golembot skill search/install`，社区技能发现和安装）~~ ✅（ClawHub 集成）
+- ~~多 bot Fleet Dashboard（`golembot fleet ls` / `golembot fleet serve`）~~ ✅（文件系统注册表，零配置发现）
+- ~~单 bot Web Dashboard，实时指标和活动流~~ ✅
+- 权限集成（`golem.yaml` 项目级权限配置）
+- WebSocket 支持（双向通信）

--- a/docs/zh/reference/coding-cli-claude-code.md
+++ b/docs/zh/reference/coding-cli-claude-code.md
@@ -1,0 +1,268 @@
+# Claude Code CLI
+
+### 官方文档
+
+**核心文档：**
+
+- 概览：https://code.claude.com/docs/en/overview
+- CLI 参考（完整命令 + 参数列表）：https://code.claude.com/docs/en/cli-reference
+- Claude Code 工作原理（架构 + 工具）：https://code.claude.com/docs/en/how-claude-code-works
+- 编程式运行 / 无头模式：https://code.claude.com/docs/en/headless
+- 记忆 & CLAUDE.md：https://code.claude.com/docs/en/memory
+- 技能：https://code.claude.com/docs/en/skills
+- 认证：https://code.claude.com/docs/en/authentication
+- 权限：https://code.claude.com/docs/en/permissions
+- 设置：https://code.claude.com/docs/en/settings
+- 模型配置：https://code.claude.com/docs/en/model-config
+
+**扩展能力：**
+
+- MCP（模型上下文协议）：https://code.claude.com/docs/en/mcp
+- 子代理：https://code.claude.com/docs/en/sub-agents
+- Hooks：https://code.claude.com/docs/en/hooks-guide
+- 插件：https://code.claude.com/docs/en/plugins
+
+**部署 & CI/CD：**
+
+- GitHub Actions：https://code.claude.com/docs/en/github-actions
+- GitLab CI/CD：https://code.claude.com/docs/en/gitlab-ci-cd
+- 费用：https://code.claude.com/docs/en/costs
+
+**Agent SDK（TypeScript / Python）：**
+
+- SDK 概览：https://platform.claude.com/docs/en/agent-sdk/overview
+- 流式输出：https://platform.claude.com/docs/en/agent-sdk/streaming-output
+- 会话：https://platform.claude.com/docs/en/agent-sdk/sessions
+
+**stream-json 事件格式速查表：**
+
+- 第三方总结：https://takopi.dev/reference/runners/claude/stream-json-cheatsheet/
+
+**完整文档索引（LLM 友好）：**
+
+- https://code.claude.com/docs/llms.txt
+
+---
+
+### 安装
+
+**前置条件**：Node.js >= 18
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+**验证安装：**
+
+```bash
+claude --version
+```
+
+---
+
+### 实际调用方式（已在 GolemBot 中验证）
+
+**二进制文件路径**：`~/.local/bin/claude`（与 Cursor Agent 的 `agent` 同目录）
+
+```bash
+~/.local/bin/claude \
+  -p "user message" \
+  --output-format stream-json \
+  --verbose \
+  --dangerously-skip-permissions \
+  [--resume <sessionId>] \
+  [--model <model-alias>]
+```
+
+**不需要 PTY**。Claude Code CLI 支持标准 stdin/stdout — 普通 `child_process.spawn()` 即可。所有引擎（Cursor、Claude Code、OpenCode、Codex）现在都使用相同的 `child_process.spawn` 方式。
+
+---
+
+### stream-json 输出格式
+
+每行一个 JSON 对象（NDJSON）；stdout 输出纯 JSON，无 ANSI 转义序列。
+
+#### 事件类型概览
+
+| 类型 | 子类型 | 含义 | 关键字段 |
+|------|--------|------|----------|
+| `system` | `init` | 初始化 | `session_id`, `model`, `cwd`, `tools[]`, `mcp_servers[]`, `apiKeySource` |
+| `assistant` | — | 助手回复（文本 / 工具调用） | `session_id`, `message.content[]` — 可能包含 `text` 和 `tool_use` 块 |
+| `user` | — | 工具执行结果 | `session_id`, `message.content[].type:"tool_result"` |
+| `result` | `success` | 对话正常结束 | `session_id`, `duration_ms`, `duration_api_ms`, `total_cost_usd`, `num_turns`, `result`, `usage` |
+| `result` | `error` | 对话异常结束 | `is_error: true`, `result`（错误信息）, `permission_denials[]` |
+
+#### 与 Cursor 的关键格式差异
+
+| 方面 | Cursor Agent | Claude Code |
+|------|-------------|-------------|
+| 文本消息 | `type:"assistant"` + `message.content[].type:"text"` | 结构相同 |
+| 工具调用开始 | `type:"tool_call"`, `subtype:"started"` | `type:"assistant"` + `message.content[].type:"tool_use"` |
+| 工具调用结果 | `type:"tool_call"`, `subtype:"completed"` | `type:"user"` + `message.content[].type:"tool_result"` |
+| 扩展结果字段 | `duration_ms` | `duration_ms`, `duration_api_ms`, `total_cost_usd`, `num_turns`, `usage` |
+| ANSI 序列 | 无（2026.02+ 后 stdout 干净） | 无（纯 stdout） |
+| 混合内容 | 从不 | **单条 assistant 消息可同时包含 text 和 tool_use 块** |
+
+#### Assistant 消息示例
+
+**纯文本回复：**
+
+```json
+{"type":"assistant","session_id":"session_01","message":{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"Planning next steps."}],"usage":{"input_tokens":120,"output_tokens":45}}}
+```
+
+**工具调用：**
+
+```json
+{"type":"assistant","session_id":"session_01","message":{"id":"msg_2","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"ls -la"}}]}}
+```
+
+**工具结果（user 事件）：**
+
+```json
+{"type":"user","session_id":"session_01","message":{"id":"msg_3","type":"message","role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"total 2\nREADME.md\nsrc\n"}]}}
+```
+
+工具结果的 content 可以是字符串或数组格式：
+
+```json
+{"type":"tool_result","tool_use_id":"toolu_2","content":[{"type":"text","text":"Task completed"}]}
+```
+
+#### Result 事件示例
+
+```json
+{"type":"result","subtype":"success","session_id":"session_01","total_cost_usd":0.0123,"is_error":false,"duration_ms":12345,"duration_api_ms":12000,"num_turns":2,"result":"Done.","usage":{"input_tokens":150,"output_tokens":70,"service_tier":"standard"}}
+```
+
+```json
+{"type":"result","subtype":"error","session_id":"session_02","total_cost_usd":0.001,"is_error":true,"duration_ms":2000,"result":"","error":"Permission denied","permission_denials":[{"tool_name":"Bash","tool_use_id":"toolu_9","tool_input":{"command":"git fetch origin main"}}]}
+```
+
+#### `--include-partial-messages` 行为
+
+不加此参数时，`assistant` 事件包含完整消息（每条消息完成后一次性输出）。
+加上此参数后，会额外输出 `stream_event` 类型事件，包含字符级增量 delta：
+
+```json
+{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"Hel"}}}
+```
+
+**流式事件序列**：`message_start` → `content_block_start` → `content_block_delta`（多个） → `content_block_stop` → `message_delta` → `message_stop` → 最后输出完整的 `assistant` 消息。
+
+**GolemBot 第一阶段不使用** `--include-partial-messages` — 完整消息模式已经够用。字符级流式输出将在后续迭代中添加。
+
+---
+
+### 会话恢复
+
+- `--resume <sessionId>` 恢复特定会话
+- `--session-id <uuid>` 使用指定 UUID 作为会话 ID
+- `--continue` / `-c` 恢复当前目录中最近的会话
+- `--fork-session` 从现有会话分叉（保留历史但使用不同 ID）
+- session_id 可从 `type: "system"` 初始化事件或 `type: "result"` 事件获取
+
+**与 Cursor 的区别**：Cursor 只能从 result 事件获取 session_id；Claude Code 在 system 初始化事件中就提供了。
+
+---
+
+### 认证方式
+
+| 方式 | 用例 | 设置 |
+|------|------|------|
+| `claude auth login` | 本地开发（推荐） | 浏览器 OAuth 流程 |
+| `ANTHROPIC_API_KEY` 环境变量 | CI/CD、脚本、无头环境 | 从 https://console.anthropic.com/settings/keys 获取 |
+| 云提供商（Bedrock/Vertex/Foundry） | 企业部署 | 平台特定的环境变量配置 |
+
+**CI/CD 场景必须使用 API key** — `claude auth login` 需要浏览器交互。
+
+---
+
+### 技能 / CLAUDE.md 机制
+
+Claude Code 的技能系统与 Cursor 有显著不同：
+
+**CLAUDE.md（项目记忆）：**
+
+| 位置 | 用途 | 加载时机 |
+|------|------|----------|
+| `./CLAUDE.md` 或 `./.claude/CLAUDE.md` | 项目级指令 | 会话启动时自动加载 |
+| `~/.claude/CLAUDE.md` | 个人级指令（所有项目） | 会话启动时自动加载 |
+| `./CLAUDE.local.md` | 个人项目级指令（不提交到 git） | 会话启动时自动加载 |
+
+**技能（`.claude/skills/`）：**
+
+- 类似 Cursor 的 `.cursor/skills/`，每个技能是包含 `SKILL.md` 的目录
+- Claude Code 自动发现 `.claude/skills/` 下的技能
+- 技能描述在会话启动时加载到上下文中；完整内容在使用时按需加载
+- 支持 frontmatter 配置：`name`、`description`、`disable-model-invocation`、`allowed-tools`、`context: fork` 等
+- 用户可通过 `/skill-name` 手动触发，Claude 也会自动判断何时使用
+
+**GolemBot 的技能注入策略：**
+
+| 引擎 | 注入方式 |
+|------|----------|
+| Cursor | 软链接 `skills/<name>` → `.cursor/skills/<name>` |
+| Claude Code | 在工作区根目录生成 `CLAUDE.md`（包含技能描述和路径引用） |
+
+---
+
+### 权限 & 安全
+
+| 参数 / 设置 | 效果 |
+|-------------|------|
+| `--dangerously-skip-permissions` | 跳过所有权限提示（无头模式必需） |
+| `--allowedTools "Bash,Read,Edit"` | 允许指定工具免确认（更细粒度） |
+| `--disallowedTools "Edit"` | 禁用指定工具 |
+| settings.json 中的 `permissions.allow/deny` | 持久化权限规则 |
+
+**GolemBot 使用 `--dangerously-skip-permissions`**（等同于 Cursor 的 `--force --trust --sandbox disabled`）。
+
+---
+
+### 模型配置
+
+| 别名 | 对应模型 | 用例 |
+|------|----------|------|
+| `sonnet` | Sonnet 4.6（最新） | 日常编码 |
+| `opus` | Opus 4.6（最新） | 复杂推理 |
+| `haiku` | Haiku | 简单任务 |
+| `opusplan` | Opus 用于规划阶段，Sonnet 用于执行 | 混合模式 |
+
+可通过 `--model <alias>` 或 `ANTHROPIC_MODEL` 环境变量设置。
+
+---
+
+### MCP 支持
+
+Claude Code 从 `.claude/mcp.json`（不是 `.cursor/mcp.json`）加载 MCP 配置。
+CLI 支持 `--mcp-config ./mcp.json` 来加载额外的 MCP 配置。
+
+---
+
+### GitHub Actions 集成
+
+```yaml
+- name: Run Claude Code
+  uses: anthropics/claude-code-action@v1
+  with:
+    prompt: "Your prompt here"
+    allowed-tools: "Bash,Read,Edit"
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+---
+
+### 已知坑点 & GolemBot 适配说明
+
+1. **不需要 PTY** — 与 Cursor 最大的区别；简单的 `child_process.spawn` 就行
+2. **不需要清除 ANSI** — stdout 是纯 JSON，不像 Cursor 的 PTY 输出会混入 ANSI 序列
+3. **混合内容块** — 单条 assistant 消息可能同时包含 `text` 和 `tool_use`；需要拆分并分别处理
+4. **tool_result 是 user 事件** — 不是 Cursor 的 `tool_call.subtype:"completed"`，而是独立的 `type:"user"` 事件
+5. **session_id 在初始化时就可用** — 不需要等到 result 事件才能获取 session_id
+6. **`--verbose` 是必需的** — 不加此参数，stream-json 只输出最终结果，不输出中间的 assistant/user 事件
+7. **result 提供更多元数据** — `total_cost_usd`、`num_turns`、`duration_api_ms`、`usage` 都可以暴露给用户
+8. **`--dangerously-skip-permissions` 是单个参数** — 不像 Cursor 需要三个参数：`--force --trust --sandbox disabled`
+9. **权限绕过需要显式启用** — 必须先用 `--allow-dangerously-skip-permissions` 启用选项，然后用 `--dangerously-skip-permissions` 或 `--permission-mode bypassPermissions` 激活。或者直接使用 `--dangerously-skip-permissions`，它会隐式允许
+10. **技能路径不同** — Cursor 用 `.cursor/skills/`，Claude Code 用 `.claude/skills/`；GolemBot 需要根据引擎选择注入方式

--- a/docs/zh/reference/coding-cli-codex.md
+++ b/docs/zh/reference/coding-cli-codex.md
@@ -1,0 +1,325 @@
+# Codex CLI
+
+### 官方文档
+
+- **文档首页:** https://developers.openai.com/codex
+- **GitHub:** https://github.com/openai/codex
+- **非交互式 (exec) 指南:** https://developers.openai.com/codex/noninteractive/
+- **CLI 参考:** https://developers.openai.com/codex/cli/reference/
+- **AGENTS.md 指南:** https://developers.openai.com/codex/guides/agents-md/
+- **认证:** https://developers.openai.com/codex/auth/
+- **安全 / 沙箱:** https://developers.openai.com/codex/security
+- **模型:** https://developers.openai.com/codex/models/
+- **SDK:** https://developers.openai.com/codex/sdk/
+- **App Server 协议:** https://developers.openai.com/codex/app-server/
+- **更新日志:** https://developers.openai.com/codex/changelog/
+
+OpenAI Codex CLI 是一个开源（Rust，96%）的终端编程代理。它可以在选定目录中读取、编辑和运行你机器上的代码。2025 年 4 月发布。支持 macOS 和 Linux；Windows 实验性支持（通过 WSL）。
+
+---
+
+### 安装
+
+```bash
+# npm (全局)
+npm install -g @openai/codex
+
+# Homebrew (macOS)
+brew install codex
+
+# GitHub Releases 平台二进制文件
+# macOS Apple Silicon: codex-aarch64-apple-darwin.tar.gz
+# macOS x86_64:        codex-x86_64-apple-darwin.tar.gz
+# Linux x86_64 (musl): codex-x86_64-unknown-linux-musl.tar.gz
+# Linux arm64 (musl):  codex-aarch64-unknown-linux-musl.tar.gz
+```
+
+二进制文件名: `codex`。npm 包: `@openai/codex`。
+
+---
+
+### 实际调用方式（GolemBot 验证）
+
+GolemBot 集成的非交互式无头调用：
+
+```bash
+# 新会话
+codex exec --json --full-auto --skip-git-repo-check "prompt here"
+
+# 恢复会话
+codex exec resume --json --full-auto --skip-git-repo-check <SESSION_ID> "continue the refactor"
+```
+
+关键标志：
+
+| 标志 | 用途 |
+|------|------|
+| `--json` | 向 stdout 输出 JSONL 事件流（机器可读） |
+| `--full-auto` | 快捷方式: `--sandbox workspace-write --ask-for-approval on-request` |
+| `--skip-git-repo-check` | 允许在 Git 仓库外运行（临时目录、CI 工作区） |
+| `--dangerously-bypass-approvals-and-sandbox` / `--yolo` | 禁用所有安全检查 — 仅在隔离容器中使用 |
+| `--model <id>` | 覆盖模型（仅 API key 模式） |
+| `--cd <path>` | 处理前设置工作目录 |
+| `--ephemeral` | 跳过会话持久化 |
+
+**标志位置:** 全局标志必须放在子命令**之后**：
+```bash
+codex exec --json --full-auto "prompt"   # ✅ 正确
+codex --json exec "prompt"               # ❌ 错误
+```
+
+**Resume 子命令标志位置:** 恢复时，所有标志放在 `resume` 之后：
+```bash
+codex exec resume --json --full-auto --skip-git-repo-check <id> "prompt"   # ✅ 正确
+codex exec --json --full-auto resume <id> "prompt"                          # ❌ 错误
+```
+
+**stdout 与 stderr 分离（集成关键）：**
+- `stdout` — 纯 JSONL 事件（仅当设置 `--json` 时）
+- `stderr` — 配置摘要、进度指示器、警告
+
+使用 `stdio: ['pipe', 'pipe', 'pipe']` 启动进程，独立消费 stdout/stderr。
+
+---
+
+### stream-json 输出格式
+
+`codex exec --json` 向 stdout 输出每行一个完整 JSON 对象（NDJSON）。事件**不是** SSE，只是换行分隔的 JSON。
+
+#### 事件类型概览
+
+| 类型 | 描述 |
+|------|------|
+| `thread.started` | 会话初始化；包含 `thread_id` |
+| `turn.started` | 新对话轮次开始 |
+| `turn.completed` | 轮次完成；包含 `usage`（输入/输出 token 数） |
+| `turn.failed` | 轮次遇到错误 |
+| `item.started` | 一个工作项已开始 |
+| `item.updated` | 工作项流式增量 |
+| `item.completed` | 工作项完成；包含最终内容 |
+| `error` | 顶层错误事件 |
+
+#### `item.type` 值（在 `item.started` / `item.completed` 中）
+
+| 项目类型 | 描述 |
+|----------|------|
+| `agent_message` | 面向用户的文本回复 — 读取 `item.text` |
+| `reasoning` | 模型内部推理 |
+| `command_execution` | 代理执行的 Shell 命令 |
+| `file_change` | 代理修改的文件 |
+| `mcp_tool_call` | MCP 服务器工具调用 |
+| `web_search` | 实时网页搜索（需要 `--search` 标志） |
+| `todo_list` | 计划/任务列表更新 |
+| `error` | 项目内的错误 |
+
+#### 示例事件（精确字段名）
+
+```json
+{"type":"thread.started","thread_id":"0199a213-81c0-7800-8aa1-bbab2a035a53"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"bash -lc ls","status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_3","type":"agent_message","text":"Here is the analysis..."}}
+{"type":"turn.completed","usage":{"input_tokens":24763,"cached_input_tokens":24448,"output_tokens":122}}
+```
+
+#### GolemBot 解析策略
+
+```
+thread.started  → 提取 thread_id → 保存为 sessionId（不 yield）
+item.completed + item.type === "agent_message" → yield { type: 'text', content: item.text }
+  （回退: item.content[].output_text 拼接，用于 OpenAI API 风格格式）
+item.completed + item.type === "command_execution" → yield { type: 'tool_call', name: item.command, args: '' }
+  + (如有 item.output) yield { type: 'tool_result', content: item.output }
+turn.completed  → yield { type: 'done', sessionId }
+  注意: Codex 不提供每次请求的费用；不输出 costUsd。
+turn.failed / error → yield { type: 'error', message: ... }
+顶层 error (Reconnecting... X/Y) → 抑制（WebSocket 重连噪音，非真实错误）
+```
+
+**已知限制（GitHub issue #5028, PR #4525）：** `mcp_tool_call` 项目在 `--json` 输出中**不包含**工具参数或结果 — 仅有服务器/工具名称。这是一个有意的改动，破坏了一些集成。完整的工具跟踪仅通过 App Server 协议可用。
+
+---
+
+### 会话恢复
+
+会话存储在 `~/.codex/sessions/`（或 `$CODEX_HOME/sessions/`）下。
+
+```bash
+# 恢复指定会话（非交互式）
+codex exec resume --json --full-auto --skip-git-repo-check <SESSION_ID> "continue the refactor"
+
+# 恢复最近会话（非交互式）
+codex exec resume --last "next step"
+
+# 也考虑所有目录（不仅仅是 cwd）
+codex exec resume --last --all "next step"
+```
+
+**捕获会话 ID：** `thread.started` 事件中的 `thread_id` 是编程获取会话 ID 的唯一方式。没有单独的环境变量或标志（待实现功能请求: issue #8923）。
+
+---
+
+### 认证方式
+
+两种认证路径：
+
+| 方式 | 用例 | 计费 |
+|------|------|------|
+| ChatGPT OAuth (浏览器) | 交互式使用, ChatGPT 订阅用户 | ChatGPT 订阅 |
+| API key | CI/CD, 无头, 编程使用 | OpenAI API 按 token 计费 |
+
+注意: Codex Cloud 任务仅在 ChatGPT 认证下可用，不支持 API key。
+
+**环境变量：**
+
+| 变量 | 用途 |
+|------|------|
+| `CODEX_API_KEY` | API 认证模式的主要环境变量（官方 CI 文档） |
+| `OPENAI_API_KEY` | 同样接受；两个都设置以确保最大兼容性 |
+| `OPENAI_BASE_URL` | 覆盖 API 端点（代理 / Azure） |
+| `CODEX_HOME` | 覆盖默认的 `~/.codex` 状态目录 |
+
+**无头 / CI 认证：**
+```bash
+# 使用 API key 预登录（存储在 ~/.codex/auth.json）
+printenv OPENAI_API_KEY | codex login --with-api-key
+
+# 单次运行内联
+CODEX_API_KEY="sk-..." codex exec --json "run tests"
+
+# 远程机器的设备代码流程
+codex login --device-code
+```
+
+**ChatGPT OAuth (浏览器登录)** — 适用于 ChatGPT Plus/Pro/Team/Enterprise 订阅用户：
+```bash
+codex login    # 打开浏览器；凭证存储在 ~/.codex/auth.json
+```
+GolemBot 自动使用存储的 OAuth 凭证 — 无需额外配置。
+
+> **模型兼容性：** `codex-mini-latest` 仅在 API key 模式下可用。使用 ChatGPT OAuth 时，不要设置 `model`，让 Codex 根据你的订阅自动选择合适的模型。
+
+**已知异常（issues #2638, #3286）：** 如果同时存在 ChatGPT 会话和 `OPENAI_API_KEY`，不同版本的行为可能不一致。对于 CI/CD，明确使用 API key 登录以避免歧义。
+
+---
+
+### 技能发现
+
+Codex 支持两种技能发现机制：
+
+#### 1. `.agents/skills/`（原生技能目录）
+
+每个技能是一个包含 `SKILL.md` 的目录，可选 frontmatter（`name`, `description`）：
+
+- **全局:** `~/.agents/skills/`
+- **项目级:** `.agents/skills/`
+
+Codex 自动发现技能目录并使用渐进式披露（先加载技能描述，按需加载完整内容）。
+
+**GolemBot 注入技能**的方式是将每个 `skills/<name>` 目录 symlink 到 `.agents/skills/<name>`。
+
+#### 2. `AGENTS.md`（项目指令）
+
+Codex 在开始工作前读取 `AGENTS.md` 文件。发现顺序：
+
+1. **全局** (`~/.codex/`): `AGENTS.override.md` → `AGENTS.md`
+2. **项目** (Git root 到 cwd): 逐层遍历，读取 `AGENTS.override.md` → `AGENTS.md` → 配置的回退文件名
+3. **合并**: 文件从 root → 最内层拼接；内层覆盖外层
+
+`~/.codex/config.toml` 中的配置：
+```toml
+project_doc_fallback_filenames = ["TEAM_GUIDE.md", ".agents.md"]
+project_doc_max_bytes = 65536    # 默认每个文件 32 KiB
+```
+
+**GolemBot** 还在工作区根目录生成 `AGENTS.md`，包含技能描述和项目指令。
+
+**受保护目录（即使在 workspace-write 模式下也始终只读）：**
+- `.git/`
+- `.agents/`
+- `.codex/`
+
+---
+
+### 权限系统
+
+#### 沙箱模式（物理能力）
+
+| 模式 | 描述 |
+|------|------|
+| `read-only` | `codex exec` 的默认模式。浏览文件，不能写入，不能访问网络 |
+| `workspace-write` | 读 + 在工作目录内写入。默认不能访问网络 |
+| `danger-full-access` | 无限制，包括网络。仅在隔离容器中使用 |
+
+#### 审批策略（何时暂停）
+
+| 策略 | 行为 |
+|------|------|
+| `untrusted` | 仅已知安全的只读命令自动运行；其他都需要确认 |
+| `on-request` | 模型决定何时请求审批 |
+| `never` | 从不提示 — 与 `danger-full-access` 配合用于完全自动化 |
+
+**`--full-auto`** = `--sandbox workspace-write` + `--ask-for-approval on-request`
+**`--yolo`** = 禁用所有沙箱和审批（仅在 Docker/隔离环境中使用）
+
+**`codex exec` (无头) 的默认行为：** 审批策略默认为 `never`，会**自动取消**所有征求请求（MCP 审批提示、沙箱升级）。使用 `--full-auto` 时，策略变为 `on-request`，自动批准命令而不是取消。
+
+#### 各操作系统沙箱实现
+
+| 操作系统 | 机制 |
+|----------|------|
+| macOS | `sandbox-exec` (Seatbelt 策略) |
+| Linux | Landlock + seccomp；可选 `bwrap` 用于网络代理 |
+| Windows (WSL) | WSL 内使用 Linux 机制 |
+
+---
+
+### 模型配置
+
+2026 年初的模型（可能变化；查看 https://developers.openai.com/codex/models/）：
+
+| 模型 ID | 描述 |
+|---------|------|
+| `5.3-codex` | 最新全尺寸模型；2026 年 2 月起对 API 用户可见 |
+| `codex-1` | 原始基于 o3 的发布模型，为软件工程调优 |
+| `codex-mini-latest` | 基于 o4-mini，低延迟，高性价比（仅 API key 模式） |
+
+切换模型：
+```bash
+codex exec --model codex-mini-latest --json "your task"
+```
+
+或在 `~/.codex/config.toml` 中：
+```toml
+model = "codex-mini-latest"
+```
+
+---
+
+### 已知踩坑与 GolemBot 适配说明
+
+1. **`--json` 标志位置**: 必须放在 `exec` 子命令之后 — `codex exec --json`，而不是 `codex --json exec`。
+
+2. **`resume` 是子命令，不是标志**: `codex exec resume <id> "prompt"` — 所有标志必须放在 `resume` 之后，不能放在之前。
+
+3. **`--skip-git-repo-check` 必须**: 没有此标志，Codex 拒绝在 Git 仓库外运行。GolemBot 使用临时目录，所以此标志是必需的。
+
+4. **工具调用参数缺失 (#5028)**: `--json` 输出中 `mcp_tool_call` 项目不包含参数或结果。仅工具名称可用。使用 App Server 协议获取完整跟踪。
+
+5. **会话 ID 仅在 JSONL 流中**: `thread.started` 事件中的 `thread_id` 是编程捕获会话 ID 的唯一方式。没有环境变量（issue #8923）。
+
+6. **双重凭证的认证冲突**: 同时存在 ChatGPT 会话 + `OPENAI_API_KEY` 可能导致不可预测的认证行为。对于 CI，明确使用 `codex login --with-api-key`。
+
+7. **`codex exec` 默认自动取消审批**: 没有 `--full-auto`，代理在无头模式下自动取消任何权限升级请求 — 需要提升权限的任务会静默失败。GolemBot 集成时始终使用 `--full-auto`。
+
+8. **WebSocket 重连噪音（OAuth 模式）**: Codex Cloud（ChatGPT OAuth 使用）总是在 WebSocket 连接失败后重试 4 次再回退到 HTTPS。这会在重试期间输出 `{"type":"error","message":"Reconnecting... X/5 ..."}` 事件。GolemBot 自动抑制这些 — 它们不是真实错误。
+
+9. **`codex-mini-latest` 模型与 OAuth 不兼容**: `codex-mini-latest` 仅在 API key 模式下可用。使用 ChatGPT OAuth 时不要设置 `model: codex-mini-latest` — 让 Codex 自动选择模型。
+
+10. **没有 `--session-key` 概念**: 会话通过存储在 `~/.codex/sessions/` 中的内部 UUID 标识。GolemBot 必须从 `thread.started` 捕获 `thread_id` 并将其持久化为 sessionId。
+
+11. **TTY 回显 bug (#3646)**: 代理执行的命令中交互式 `sudo` 提示可能导致终端挂起。避免在 prompt 中使用 sudo。
+
+12. **输入大小上限**: 自 v0.106.0 起共享 ~1M 字符输入上限，防止超大输入导致挂起。
+
+13. **快速发布节奏**: Codex CLI 迭代很快；在 CI 中使用前，先用已安装版本的 `codex exec --help` 验证标志语法。

--- a/docs/zh/reference/coding-cli-comparison.md
+++ b/docs/zh/reference/coding-cli-comparison.md
@@ -1,0 +1,84 @@
+# 四引擎对比矩阵
+
+Cursor vs Claude Code vs OpenCode vs Codex — GolemBot 支持的所有引擎的并排参考对比。
+
+## 基本属性
+
+| 维度 | Cursor Agent | Claude Code | OpenCode | Codex CLI |
+|------|-------------|-------------|----------|-----------| 
+| 类型 | IDE 配套 CLI | 官方 CLI Agent | 独立开源 Agent | OpenAI 官方 CLI Agent |
+| 开源 | 否 | 否 | 是 (Apache-2.0) | 是 (Apache-2.0, Rust) |
+| LLM 支持 | Cursor 后端 (带路由) | 仅 Anthropic 模型 | 75+ 提供商 | OpenAI 模型 (codex-1, codex-mini-latest 等) |
+| 安装 | `curl https://cursor.com/install -fsS \| bash` | `npm i -g @anthropic-ai/claude-code` | `npm i -g opencode-ai` | `npm i -g @openai/codex` |
+| 二进制文件名 | `agent` | `claude` | `opencode` | `codex` |
+| PTY 要求 | 不需要 (`child_process.spawn`) | 不需要 (`child_process.spawn`) | 不需要 (`child_process.spawn`) | 不需要 (`child_process.spawn`) |
+
+## 调用方式
+
+| 维度 | Cursor Agent | Claude Code | OpenCode | Codex CLI |
+|------|-------------|-------------|----------|-----------| 
+| 非交互式命令 | `agent -p "prompt"` | `claude -p "prompt"` | `opencode run "prompt"` | `codex exec "prompt"` |
+| JSON 输出标志 | `--output-format stream-json` | `--output-format stream-json` | `--format json` | `--json` (跟在 `exec` 后) |
+| 模型选择 | `--model <alias>` | `--model <alias>` | `--model provider/model` | `--model <id>` |
+| 权限绕过 | `--force --trust --sandbox disabled` | `--dangerously-skip-permissions` | 权限配置 `"*": "allow"` | `--full-auto` 或 `--yolo` |
+| 核心无头参数 | `--approve-mcps` | `--dangerously-skip-permissions` | 权限配置 `"*": "allow"` | `--full-auto` |
+| 详细输出 | 默认 | `--verbose` (必须) | 默认 | 自动输出到 stderr |
+
+## 会话管理
+
+| 维度 | Cursor Agent | Claude Code | OpenCode | Codex CLI |
+|------|-------------|-------------|----------|-----------| 
+| 恢复指定会话 | `--resume <uuid>` | `--resume <uuid>` | `--session <ses_xxx>` | `codex exec resume <thread_id> "prompt"` |
+| 恢复最近会话 | `--resume` | `--continue` | `--continue` | `codex exec resume --last "prompt"` |
+| 分叉会话 | 不支持 | `--fork-session` | `--fork` | `codex fork` (仅 TUI) |
+| 导出会话 | 不支持 | 不支持 | `opencode export <id>` | 不支持 |
+| 会话 ID 格式 | UUID | UUID | `ses_XXXXXXXX` | UUID (`thread.started` 事件中的 `thread_id`) |
+| 会话存储 | `~/.cursor/` | `~/.claude/` | `~/.local/share/opencode/` | `~/.codex/sessions/` |
+| 跳过持久化 | 不支持 | 不支持 | 不支持 | `--ephemeral` |
+
+## 认证
+
+| 维度 | Cursor Agent | Claude Code | OpenCode | Codex CLI |
+|------|-------------|-------------|----------|-----------| 
+| API Key 变量 | `CURSOR_API_KEY` | `ANTHROPIC_API_KEY` | 取决于提供商 | `OPENAI_API_KEY` / `CODEX_API_KEY` |
+| 本地登录 | `agent login` (浏览器 OAuth) | `claude auth login` | `opencode auth login` | `codex login` (浏览器或 `--with-api-key`) |
+| 订阅支持 | 原生 (Cursor Pro) | OAuth + `apiKeyHelper` | 不适用 | ChatGPT 订阅 (OAuth) |
+| CI/CD 认证 | `CURSOR_API_KEY` | `ANTHROPIC_API_KEY` | 提供商特定环境变量 | `printenv OPENAI_API_KEY \| codex login --with-api-key` |
+| OpenRouter | 不支持 | 原生不支持 | 原生支持 (`OPENROUTER_API_KEY`) | 不支持 |
+
+## 技能 / 规则系统
+
+| 维度 | Cursor Agent | Claude Code | OpenCode | Codex CLI |
+|------|-------------|-------------|----------|-----------| 
+| 技能路径 | `.cursor/skills/` | `.claude/skills/` | `.opencode/skills/` + `.claude/skills/` + `.agents/skills/` | `.agents/skills/` |
+| 规则文件 | `.cursor/rules/*.mdc` | `CLAUDE.md` | `AGENTS.md` (首选) / `CLAUDE.md` | `AGENTS.md` (自动发现 root → cwd) |
+| 规则回退配置 | 不支持 | 不支持 | 不支持 | `config.toml` 中的 `project_doc_fallback_filenames` |
+| 技能格式 | `SKILL.md` | `SKILL.md` | `SKILL.md` (带 frontmatter) | `SKILL.md` (在 `.agents/skills/` 中) + `AGENTS.md` |
+| 按需加载 | 是 (Agent 自动) | 是 (Agent 自动) | 是 (通过 `skill()` 工具) | 不适用 |
+| 全局技能 | `~/.cursor/skills/` | `~/.claude/skills/` | `~/.config/opencode/skills/` | `~/.codex/AGENTS.md` |
+
+## 工具与扩展
+
+| 维度 | Cursor Agent | Claude Code | OpenCode | Codex CLI |
+|------|-------------|-------------|----------|-----------| 
+| 内置工具 | IDE 集成 | bash/read/write/edit/grep 等 | bash/read/write/edit/grep/glob 等 | bash/read/write/edit 等 |
+| MCP 支持 | `.cursor/mcp.json` | `.claude/mcp.json` | `opencode.json` | `~/.codex/config.toml` (通过 `mcp` 命令) |
+| 网页搜索 | 不支持 | 不支持 | 不支持 | `--search` 标志 |
+| 图片输入 | 不支持 | 不支持 | 不支持 | `--image <path>` |
+| 子代理 | 不支持 | 不支持 | `explore`、`general` (可并行) | Codex Cloud (异步任务) |
+| GitHub Actions | 支持 (`curl https://cursor.com/install`) | 支持 (官方 Action) | 支持 (官方 Action) | 支持 (`npm i -g @openai/codex`) |
+| HTTP Server API | 不支持 | 不支持 | 完整 OpenAPI (`opencode serve`) | App Server (基于 stdio 的 JSON-RPC 2.0) |
+| TypeScript SDK | 不支持 | 不支持 | 不支持 | `@openai/codex-sdk` (Node 18+) |
+
+## GolemBot 引擎集成
+
+| 维度 | CursorEngine | ClaudeCodeEngine | OpenCodeEngine | CodexEngine |
+|------|-------------|-----------------|----------------|-------------|
+| 启动方式 | `child_process.spawn` | `child_process.spawn` | `child_process.spawn` | `child_process.spawn` |
+| 解析函数 | `parseStreamLine()` | `parseClaudeStreamLine()` | `parseOpenCodeStreamLine()` | `parseCodexStreamLine()` |
+| 技能注入 | symlink → `.cursor/skills/` | symlink → `.claude/skills/` + `CLAUDE.md` | symlink → `.opencode/skills/` | symlink → `.agents/skills/` + `AGENTS.md` |
+| 配置生成 | `.cursor/cli.json` | `CLAUDE.md` | `opencode.json` | `~/.codex/config.toml` (可选) |
+| API Key 注入 | `CURSOR_API_KEY` | `ANTHROPIC_API_KEY` | 提供商特定环境变量 | `OPENAI_API_KEY` |
+| 会话 ID 来源 | `done` 事件 `sessionId` 字段 | `done` 事件 `sessionId` 字段 | `done` 事件 `sessionId` 字段 | `thread.started` 事件 `thread_id` 字段 |
+| 冷启动 | 快 (~1s) | 中等 (~2-3s) | 慢 (5-10s, 推荐 HTTP serve 模式) | 中等 (~2-3s) |
+| 费用追踪 | `duration_ms` | `total_cost_usd` + `num_turns` | `cost` + `tokens` (含缓存明细) | `usage.input_tokens` + `usage.output_tokens` (无费用) |

--- a/docs/zh/reference/coding-cli-cursor.md
+++ b/docs/zh/reference/coding-cli-cursor.md
@@ -1,0 +1,269 @@
+# Cursor Agent CLI
+
+### 官方文档
+
+- 概览：https://cursor.com/docs/cli/overview
+- 安装：https://cursor.com/docs/cli/installation
+- 使用 Agent：https://cursor.com/docs/cli/using
+- Shell 模式：https://cursor.com/docs/cli/shell-mode
+- MCP：https://cursor.com/docs/cli/mcp
+- 无头模式：https://cursor.com/docs/cli/headless
+- GitHub Actions：https://cursor.com/docs/cli/github-actions
+- 斜杠命令：https://cursor.com/docs/cli/reference/slash-commands
+- 参数：https://cursor.com/docs/cli/reference/parameters
+- 认证：https://cursor.com/docs/cli/reference/authentication
+- 权限：https://cursor.com/docs/cli/reference/permissions
+- 配置：https://cursor.com/docs/cli/reference/configuration
+- 输出格式：https://cursor.com/docs/cli/reference/output-format
+- 终端设置：https://cursor.com/docs/cli/reference/terminal-setup
+
+---
+
+### 安装
+
+**前置条件**：无 — Cursor CLI (`agent`) 是独立二进制文件，**不需要**安装 Cursor IDE。
+
+**通过 curl 安装**（推荐）：
+
+```bash
+curl https://cursor.com/install -fsS | bash
+```
+
+会把 `agent` 二进制文件安装到 `~/.local/bin/agent`（Linux/macOS）或 `~/.cursor/bin/agent`（部分 CI 环境）。确保安装目录在 `PATH` 中：
+
+```bash
+echo "$HOME/.local/bin" >> ~/.bashrc   # 或 ~/.zshrc
+# 在 GitHub Actions 中：
+echo "$HOME/.cursor/bin" >> $GITHUB_PATH
+```
+
+**验证安装：**
+
+```bash
+agent --version
+```
+
+---
+
+### 实际调用方式（已在 GolemBot 中验证）
+
+**二进制文件名**：`agent`（不是 `cursor`）
+**二进制文件路径**：`~/.local/bin/agent`
+
+```bash
+agent \
+  -p "user message" \
+  --output-format stream-json \
+  --stream-partial-output \
+  --workspace /path/to/assistant-dir \
+  --force --trust --sandbox disabled \
+  --approve-mcps \
+  [--resume <sessionId>] \
+  [--model <model-name>]
+```
+
+**不需要 PTY**（CLI 版本 2026.02+ 起）。已验证 `child_process.spawn` 在 stdout 上产生干净的 NDJSON，零 ANSI 转义序列。GolemBot 已将 `CursorEngine` 从 `node-pty` 迁移到标准 `child_process.spawn`，消除了唯一的原生 C++ 依赖。`stripAnsi()` 作为安全网保留，但预期不会被触发。
+
+---
+
+### stream-json 输出格式
+
+每行一个 JSON 对象（NDJSON）。使用 `child_process.spawn`（CLI 版本 2026.02+ 已验证），stdout 产生干净的 JSON，无 ANSI 转义序列。`stripAnsi()` 作为安全网保留。
+
+#### 事件类型概览
+
+| 类型 | 子类型 | 含义 | 关键字段 |
+|------|--------|------|----------|
+| `system` | `init` | 初始化 | `session_id`, `model`, `cwd`, `apiKeySource` |
+| `user` | — | 用户输入（回显） | `message.content[].text` |
+| `assistant` | — | 助手回复 | `message.content[].text` — 数组，过滤 `type=text` 并拼接 |
+| `tool_call` | `started` | 工具调用开始 | `call_id`, `tool_call.<XxxToolCall>.args` |
+| `tool_call` | `completed` | 工具调用完成 | `call_id`, `tool_call.<XxxToolCall>.result` |
+| `result` | `success` | 对话正常结束 | `session_id`, `duration_ms`, `result`（全文拼接） |
+| `result` | `error` | 对话异常结束 | `is_error: true`, `result`（错误信息） |
+
+#### `--stream-partial-output` 行为
+
+不加此参数时，`assistant` 事件包含两次工具调用之间的**完整文本**（一次性输出）。
+加上此参数后，`assistant` 事件变为**字符级增量 delta** — 需要拼接多个 `assistant` 事件才能得到完整文本。
+
+**关键坑点**：每个分段（两次工具调用之间的文本）的所有 delta 发完后，Cursor 会额外发一个**汇总事件**，内容 = 该分段所有 delta 的拼接。如果不跳过汇总事件，**用户会看到每段文本重复出现两次**。GolemBot 在 CursorEngine 层通过累积文本比较来检测并跳过汇总事件。
+
+**GolemBot 已启用此参数**，实现了真正的逐字符流式输出。
+
+#### tool_call 结构
+
+**标准结构（绝大多数工具）：**
+
+```json
+{
+  "type": "tool_call",
+  "subtype": "started",
+  "call_id": "toolu_vrtx_01NnjaR886UcE8whekg2MGJd",
+  "tool_call": {
+    "readToolCall": {
+      "args": { "path": "sales.csv" }
+    }
+  }
+}
+```
+
+**完成事件包含结果：**
+
+```json
+{
+  "type": "tool_call",
+  "subtype": "completed",
+  "call_id": "toolu_vrtx_01NnjaR886UcE8whekg2MGJd",
+  "tool_call": {
+    "readToolCall": {
+      "args": { "path": "sales.csv" },
+      "result": {
+        "success": {
+          "content": "product,date,quantity...",
+          "totalLines": 54,
+          "totalChars": 1254
+        }
+      }
+    }
+  }
+}
+```
+
+**已知工具名称（key 不是固定枚举 — 必须用 `*ToolCall` 动态匹配）：**
+- `readToolCall` — 读取文件
+- `writeToolCall` — 写入文件
+- `ShellToolCall` — 执行命令
+
+**替代结构（部分工具使用 `function` 格式）：**
+
+```json
+{
+  "type": "tool_call",
+  "subtype": "started",
+  "tool_call": {
+    "function": {
+      "name": "tool_name",
+      "arguments": "{\"query\": \"test\"}"
+    }
+  }
+}
+```
+
+**GolemBot 的解析策略：**
+- `subtype: "started"` 或无 subtype → yield `{ type: 'tool_call', name, args }`
+- `subtype: "completed"` → yield `{ type: 'tool_result', content }`（提取 result 字段）
+- 同时处理 `*ToolCall` 和 `function` 两种结构
+
+---
+
+### 会话恢复
+
+- `--resume <sessionId>` 参数让 Agent 在同一上下文中继续对话
+- `--continue` 是 `--resume=-1` 的别名，恢复最近一次会话
+- `agent ls` 列出所有历史会话
+- session_id 从 `type: "result"` 事件的 `session_id` 字段获取
+- 恢复失败表现为：Agent 进程以非零退出码退出，或 result 事件返回 `is_error: true`
+- 失败消息通常包含 "resume" 或 "session" 关键词
+
+**GolemBot 的降级策略**：检测到恢复失败 → 清除已保存的会话 → 不带 `--resume` 重试一次
+
+---
+
+### 认证方式
+
+| 方式 | 用例 | 设置 |
+|------|------|------|
+| `agent login` | 本地开发（推荐） | 浏览器 OAuth 流程，凭据存储在本地 |
+| `CURSOR_API_KEY` 环境变量 | CI/CD、脚本、无头环境 | 从 Cursor Dashboard → Integrations → User API Keys 获取 |
+| `--api-key <key>` 参数 | 一次性调用 | 直接传入 |
+
+**CI/CD 场景必须使用 API key** — `agent login` 需要浏览器交互。
+
+---
+
+### 技能自动发现机制
+
+Cursor Agent 启动时会读取：
+1. `.cursor/skills/` 目录下的所有 `SKILL.md` 文件
+2. 项目根目录的 `AGENTS.md` 和 `CLAUDE.md`（如果存在）
+3. `.cursor/rules/` 目录下的规则文件
+
+Agent **自主决定**何时使用哪个技能 — 用户无需在提示词中指定。
+
+GolemBot 的做法是将 `skills/<name>` 软链接到 `.cursor/skills/<name>`，每次调用前刷新软链接。
+
+---
+
+### 权限系统
+
+可以通过 `~/.cursor/cli-config.json`（全局）或 `.cursor/cli.json`（项目级）配置细粒度权限：
+
+| 格式 | 示例 | 效果 |
+|------|------|------|
+| `Shell(cmd)` | `Shell(git)`, `Shell(npm)` | 控制可执行哪些命令 |
+| `Read(glob)` | `Read(src/**/*.ts)` | 控制可读取哪些文件 |
+| `Write(glob)` | `Write(docs/**/**)` | 控制可写入哪些文件 |
+| `WebFetch(domain)` | `WebFetch(*.github.com)` | 控制可访问哪些域名 |
+| `Mcp(server:tool)` | `Mcp(datadog:*)` | 控制可使用哪些 MCP 工具 |
+
+Deny 规则优先于 Allow 规则。在安全敏感场景（如 CI/CD 代码审查机器人）中很有价值。
+
+---
+
+### MCP 支持
+
+Agent 自动检测并使用 `.cursor/mcp.json` 中配置的 MCP 服务器。
+- `--approve-mcps` 参数跳过 MCP 批准提示（无头模式必需 — **GolemBot 已启用**）
+- `agent mcp list` 显示已配置的 MCP 服务器
+- `agent mcp list-tools <server>` 显示特定 MCP 服务器提供的工具
+
+---
+
+### Cloud Agent
+
+- `-c` / `--cloud` 启动 Cloud Agent，将对话推送到云端持续执行
+- 在交互式会话中，消息前缀 `&` 可将任务发送给 Cloud Agent
+- 适合长时间运行的任务 — 用户不需要等待
+- 在 cursor.com/agents 查看和继续云端任务
+
+---
+
+### 配置文件
+
+| 文件 | 位置 | 内容 |
+|------|------|------|
+| `cli-config.json` | `~/.cursor/cli-config.json` | 全局配置（权限、vim 模式、网络代理等） |
+| `cli.json` | `.cursor/cli.json`（项目级） | 仅权限配置 |
+
+---
+
+### GitHub Actions 集成
+
+```yaml
+- name: Install Cursor CLI
+  run: |
+    curl https://cursor.com/install -fsS | bash
+    echo "$HOME/.cursor/bin" >> $GITHUB_PATH
+
+- name: Run Cursor Agent
+  env:
+    CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+  run: |
+    agent -p "Your prompt here" --model gpt-5.2
+```
+
+---
+
+### 已知坑点
+
+1. **stdout 缓冲区不按行分割** — `data` 事件可能在任意字节边界触发；你必须手动维护缓冲区并按 `\n` 分割
+2. **进程退出时缓冲区可能有残余数据** — 必须在 `close` 回调中排空剩余内容
+3. **ANSI 清除作为安全网保留** — 使用 `child_process.spawn`（2026.02+）后，stdout 是干净的 JSON。`stripAnsi()` 保留是为了向后兼容可能通过 PTY 调用的旧版 CLI
+4. **`--sandbox disabled` 是必需的** — 否则 Agent 在某些操作（如写文件）上会因权限问题失败
+5. **`--force --trust` 是必需的** — 跳过交互式确认；否则 Agent 等待用户输入而挂起
+6. **`--approve-mcps` 应始终包含** — 否则当存在 MCP 配置时，会交互式询问是否批准，导致无头模式挂起
+7. **`--stream-partial-output` 导致汇总重复** — 每个分段的 delta 发完后，会额外发送一个汇总事件（内容 = 所有 delta 拼接）。消费者必须去重，否则文本会翻倍。GolemBot 通过累积比较检测汇总事件并跳过
+8. **tool_call 有 started/completed 两种事件** — 如果不区分，每次工具调用会被处理两次
+9. **tool_call 的 key 名称不固定** — 不能硬编码 `readToolCall`；必须动态匹配 `*ToolCall` 后缀，而且部分工具使用 `function` 结构
+10. **`result` 事件的 `result` 字段是全文拼接** — 不只是最后一段，而是所有助手文本的拼接

--- a/docs/zh/reference/coding-cli-docs.md
+++ b/docs/zh/reference/coding-cli-docs.md
@@ -1,0 +1,14 @@
+# Coding Agent CLI — 实战笔记
+
+GolemBot 支持的各 Coding Agent CLI 深度技术参考。包含经过验证的调用方法、输出格式规范、会话管理细节、认证选项以及踩坑记录 — 基于 GolemBot 实际集成工作的第一手经验。
+
+## 各引擎参考
+
+- **[Cursor Agent CLI](./coding-cli-cursor)** — `agent` 二进制文件, stream-json, `--stream-partial-output` 去重
+- **[Claude Code CLI](./coding-cli-claude-code)** — `claude` 二进制文件, stream-json, assistant/user 混合事件
+- **[OpenCode CLI](./coding-cli-opencode)** — `opencode` 二进制文件, NDJSON parts, HTTP Server API 选项
+- **[Codex CLI](./coding-cli-codex)** — `codex` 二进制文件, NDJSON, ChatGPT OAuth, `--skip-git-repo-check`
+
+## 跨引擎对比
+
+- **[四引擎对比矩阵](./coding-cli-comparison)** — 所有四个引擎的调用、会话、认证、技能、工具以及 GolemBot 集成的并排对比

--- a/docs/zh/reference/coding-cli-opencode.md
+++ b/docs/zh/reference/coding-cli-opencode.md
@@ -1,0 +1,455 @@
+# OpenCode CLI
+
+### 官方文档
+
+**核心文档：**
+
+- 介绍：https://opencode.ai/docs
+- 配置：https://opencode.ai/docs/config
+- CLI 命令参考：https://opencode.ai/docs/cli
+- 提供商（75+ LLM 提供商）：https://opencode.ai/docs/providers
+- 代理系统：https://opencode.ai/docs/agents
+- 技能（Agent Skills）：https://opencode.ai/docs/skills
+- 规则（AGENTS.md）：https://opencode.ai/docs/rules
+- 权限系统：https://opencode.ai/docs/permissions
+- 内置工具：https://opencode.ai/docs/tools
+- 自定义工具：https://opencode.ai/docs/custom-tools
+- 模型配置：https://opencode.ai/docs/models
+
+**扩展能力：**
+
+- MCP 服务器：https://opencode.ai/docs/mcp-servers
+- 插件系统：https://opencode.ai/docs/plugins
+- HTTP Server API：https://opencode.ai/docs/server
+- Web 界面：https://opencode.ai/docs/web
+- ACP 协议：https://opencode.ai/docs/acp
+
+**部署 & CI/CD：**
+
+- GitHub Actions：https://opencode.ai/docs/github
+- 网络 / 代理：https://opencode.ai/docs/network
+- 企业版：https://opencode.ai/docs/enterprise
+
+**项目信息：**
+
+- GitHub：https://github.com/anomalyco/opencode（113K+ stars）
+- npm 包：`opencode-ai`
+- 版本：v1.1.28（截至 2026-03）
+
+---
+
+### 核心定位差异
+
+**OpenCode 不是像 Cursor/Claude Code 那样的"IDE 配套 CLI" — 它是独立的开源 AI 编程代理。**它直接调用 LLM API（通过 AI SDK + Models.dev），实现了自己的工具系统（bash/read/write/edit/grep/glob 等），并独立管理会话和上下文。
+
+与 Cursor Agent 和 Claude Code 的关键区别：
+
+| | Cursor Agent | Claude Code | OpenCode |
+|---|---|---|---|
+| 本质 | Cursor IDE 的 CLI 模式 | Anthropic 的 CLI 代理 | 独立的开源代理 |
+| LLM | Cursor 后端（带路由） | Anthropic API | 75+ 提供商可选 |
+| 工具 | Cursor 内置 | Claude Code 内置 | 自研 + MCP + 自定义 |
+
+---
+
+### 安装
+
+**前置条件**：Node.js >= 18（npm 安装）或 Go >= 1.22（源码编译）
+
+**通过 npm 安装**（推荐）：
+
+```bash
+npm install -g opencode-ai
+```
+
+**替代方式 — 通过 Go 安装：**
+
+```bash
+go install github.com/anomalyco/opencode@latest
+```
+
+**验证安装：**
+
+```bash
+opencode --version
+```
+
+---
+
+### 实际调用方式（已在 GolemBot 中验证）
+
+**二进制文件路径**：取决于 Node 版本管理器，如 `~/.nvm/versions/node/v22.10.0/bin/opencode`
+
+```bash
+opencode run "user message" \
+  --format json \
+  --model provider/model \
+  [--session <sessionId>] \
+  [--continue] \
+  [--agent <agentName>] \
+  [--attach http://localhost:4096]
+```
+
+**不需要 PTY**。OpenCode 是标准 CLI；普通 `child_process.spawn()` 即可（与 Claude Code 相同）。
+
+**关键参数说明：**
+
+| 参数 | 效果 | 备注 |
+|------|------|------|
+| `--format json` | 输出原始 JSON 事件（NDJSON） | 替代默认的格式化文本输出 |
+| `--model provider/model` | 指定模型（如 `anthropic/claude-sonnet-4-5`） | 格式为 `provider/model`，不像 Claude Code 那样用别名 |
+| `--session <id>` | 恢复特定会话 | 会话 ID 格式：`ses_XXXXXXXX` |
+| `--continue` / `-c` | 恢复最近的会话 | |
+| `--fork` | 分叉会话（保留历史但使用新 ID） | 必须与 `--session` 或 `--continue` 配合使用 |
+| `--agent <name>` | 指定代理（如 `build`、`plan`） | 默认是 `build`（完整功能） |
+| `--attach <url>` | 连接到运行中的 serve 实例 | 避免冷启动，生产环境推荐 |
+| `--port <n>` | 指定本地服务器端口 | 默认随机端口 |
+
+---
+
+### JSON 输出格式（`--format json`）
+
+`opencode run --format json` 输出 NDJSON。**事件结构与 Cursor/Claude Code 的 stream-json 完全不同。**
+
+#### 已观测的事件类型
+
+**错误事件：**
+
+```json
+{
+  "type": "error",
+  "timestamp": 1772335804867,
+  "sessionID": "ses_3588dd885ffeJynG8QZsSrpPiL",
+  "error": {
+    "name": "APIError",
+    "data": {
+      "message": "Your credit balance is too low...",
+      "statusCode": 400,
+      "isRetryable": false
+    }
+  }
+}
+```
+
+**会话数据结构**（通过 `opencode export <sessionId>` 获取完整格式）：
+
+```json
+{
+  "info": {
+    "id": "ses_XXX",
+    "title": "...",
+    "time": { "created": 1772335636895, "updated": 1772335640665 }
+  },
+  "messages": [
+    {
+      "info": {
+        "id": "msg_XXX",
+        "role": "user|assistant",
+        "agent": "build",
+        "model": { "providerID": "...", "modelID": "..." },
+        "cost": 0,
+        "tokens": {
+          "input": 11103, "output": 35, "reasoning": 33,
+          "cache": { "read": 397, "write": 0 }
+        },
+        "finish": "stop"
+      },
+      "parts": [
+        { "type": "text", "text": "..." },
+        { "type": "step-start" },
+        { "type": "reasoning", "text": "...", "time": { "start": 0, "end": 0 } },
+        { "type": "step-finish", "reason": "stop", "cost": 0, "tokens": {} }
+      ]
+    }
+  ]
+}
+```
+
+**消息 parts 类型概览：**
+
+| part.type | 含义 | 关键字段 |
+|-----------|------|----------|
+| `text` | 文本内容 | `text`, `time` |
+| `step-start` | 推理步骤开始 | |
+| `step-finish` | 推理步骤结束 | `reason`, `cost`, `tokens` |
+| `reasoning` | 推理过程（思维链） | `text`, `time` |
+| `tool-invocation` | 工具调用 | `toolName`, `args`, `result` |
+
+**与 Cursor/Claude Code 的格式差异：**
+
+| 方面 | Cursor | Claude Code | OpenCode |
+|------|--------|-------------|----------|
+| 流式格式 | `--output-format stream-json` | `--output-format stream-json` | `--format json` |
+| 文本事件 | `type:"assistant"` | `type:"assistant"` + `content[].type:"text"` | part.type: `text` |
+| 工具调用 | `type:"tool_call"` + started/completed | `type:"assistant"` + tool_use 块 | part.type: `tool-invocation` |
+| 结束事件 | `type:"result"` | `type:"result"` | step-finish（带 cost/tokens） |
+| 错误事件 | `type:"result"` + `is_error:true` | `type:"result"` + `is_error:true` | `type:"error"` + error 对象 |
+| 元数据 | `duration_ms` | `duration_ms`, `total_cost_usd`, `num_turns` | `cost`, `tokens`（含推理 + 缓存明细） |
+| ANSI | 无（2026.02+ 后 stdout 干净） | 无 | 无 |
+
+**说明**：以上流式事件结构已通过 OpenRouter + Anthropic 模型的实际测试验证。GolemBot 中的 `OpenCodeEngine` 已完整实现并通过端到端测试。关键发现：OpenCode 以完整块发送文本内容（不是字符级 delta），类似于 Claude Code 不加 `--include-partial-messages` 时的行为。
+
+---
+
+### 替代方案：通过 HTTP Server API 集成
+
+OpenCode 提供完整的 HTTP Server（OpenAPI 3.1 规范），给 GolemBot **两种集成方式**：
+
+**方式 A：CLI 模式**（与 Cursor/Claude Code 相同）
+```bash
+opencode run --format json "prompt"
+```
+
+**方式 B：HTTP Server 模式**（OpenCode 独有）
+```bash
+opencode serve --port 4096
+# → POST /session/:id/message { parts: [{ type: "text", text: "prompt" }] }
+# → GET /event (SSE stream)
+```
+
+关键 HTTP Server API 端点：
+
+| 方法 | 路径 | 用途 |
+|------|------|------|
+| `POST` | `/session` | 创建新会话 |
+| `POST` | `/session/:id/message` | 发送消息（同步，等待完成） |
+| `POST` | `/session/:id/prompt_async` | 异步发送消息 |
+| `POST` | `/session/:id/abort` | 中止运行中的会话 |
+| `GET` | `/session/:id/message` | 获取消息列表 |
+| `GET` | `/event` | SSE 事件流 |
+| `GET` | `/global/health` | 健康检查 |
+| `DELETE` | `/session/:id` | 删除会话 |
+| `POST` | `/session/:id/fork` | 分叉会话 |
+| `POST` | `/session/:id/share` | 分享会话 |
+
+HTTP 模式的优势：避免每次 `opencode run` 的冷启动（5-10 秒），复用单个服务器实例处理多个对话。
+
+---
+
+### 会话管理
+
+| 操作 | CLI 命令 | 说明 |
+|------|----------|------|
+| 列出会话 | `opencode session list --format json` | 返回 JSON 数组 |
+| 恢复会话 | `opencode run --session <id> "message"` | |
+| 恢复最近的 | `opencode run --continue "message"` | |
+| 分叉会话 | `opencode run --session <id> --fork "message"` | |
+| 导出会话 | `opencode export <id>` | 完整 JSON（所有消息和 parts） |
+| 导入会话 | `opencode import <file\|url>` | |
+| 删除会话 | HTTP：`DELETE /session/:id` | 尚无直接 CLI 命令 |
+| 查看统计 | `opencode stats` | Token 使用量和费用统计 |
+
+**会话 ID 格式**：`ses_XXXXXXXXXXXXXXXX`（不同于 Cursor/Claude Code 的 UUID 格式）
+
+---
+
+### 认证方式
+
+OpenCode 支持 75+ LLM 提供商；认证方式取决于选择的提供商：
+
+| 方式 | 用例 | 设置 |
+|------|------|------|
+| `opencode auth login` / `/connect` | 本地开发 | 在 TUI 中交互式完成，凭据存储到 `~/.local/share/opencode/auth.json` |
+| 提供商环境变量 | CI/CD、脚本 | `ANTHROPIC_API_KEY`、`OPENAI_API_KEY`、`OPENROUTER_API_KEY` 等 |
+| OpenCode Zen / Go | 官方托管提供商 | 统一 API Key，经 OpenCode 团队验证 |
+| `.env` 文件 | 项目级配置 | OpenCode 启动时自动从项目目录加载 `.env` |
+
+**常用提供商环境变量：**
+
+| 提供商 | 环境变量 | 模型格式示例 |
+|--------|----------|-------------|
+| Anthropic | `ANTHROPIC_API_KEY` | `anthropic/claude-sonnet-4-5` |
+| OpenAI | `OPENAI_API_KEY` | `openai/gpt-5` |
+| Google | `GOOGLE_GENERATIVE_AI_API_KEY` | `google/gemini-2.5-pro` |
+| OpenRouter | `OPENROUTER_API_KEY` | `openrouter/anthropic/claude-sonnet-4-5` |
+| Amazon Bedrock | `AWS_*` 系列 | `amazon-bedrock/...` |
+
+**与 Cursor/Claude Code 的区别**：Cursor 只需 `CURSOR_API_KEY`，Claude Code 只需 `ANTHROPIC_API_KEY`。由于 OpenCode 支持多个提供商，你必须设置**所选提供商对应的**环境变量。在与 GolemBot 的 `InvokeOpts.apiKey` 集成时，需要知道目标提供商才能设置正确的环境变量名。
+
+---
+
+### 技能机制
+
+OpenCode 的技能系统与 Claude Code 高度兼容。搜索路径：
+
+| 位置 | 作用域 | 说明 |
+|------|--------|------|
+| `.opencode/skills/*/SKILL.md` | 项目级 | OpenCode 原生路径 |
+| `.claude/skills/*/SKILL.md` | 项目级 | Claude Code 兼容（可通过 `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1` 禁用） |
+| `.agents/skills/*/SKILL.md` | 项目级 | 通用标准路径 |
+| `~/.config/opencode/skills/*/SKILL.md` | 全局 | 用户级 |
+| `~/.claude/skills/*/SKILL.md` | 全局 | Claude Code 兼容 |
+| `~/.agents/skills/*/SKILL.md` | 全局 | 通用标准 |
+
+**技能发现机制**：OpenCode 从当前目录向上遍历到 git 工作树根目录，沿途加载所有匹配的 `skills/*/SKILL.md`。
+
+**按需加载**：代理启动时，只有技能名称和描述可见（注入到 `skill` 工具描述中）；当代理决定使用某个技能时，通过 `skill({ name: "xxx" })` 工具调用加载完整内容。
+
+**SKILL.md frontmatter 要求：**
+
+```yaml
+---
+name: git-release          # 必填，须与目录名一致，小写 + 连字符
+description: Create releases  # 必填，1-1024 字符
+license: MIT               # 可选
+compatibility: opencode    # 可选
+metadata:                  # 可选，字符串到字符串的映射
+  audience: maintainers
+---
+```
+
+**GolemBot 的注入策略选项：**
+- 选项 1：软链接到 `.opencode/skills/`（最规范）
+- 选项 2：软链接到 `.agents/skills/`（通用标准，未来其他代理也能读取）
+- 选项 3：复用 Claude Code 的 `.claude/skills/` 软链接（OpenCode 兼容读取）
+
+---
+
+### 规则 / AGENTS.md
+
+OpenCode 的规则系统与 GolemBot 的 `AGENTS.md` 生成机制完美兼容：
+
+| 位置 | 优先级 | 说明 |
+|------|--------|------|
+| `AGENTS.md`（项目根目录） | 高 | OpenCode 原生，优先于 CLAUDE.md |
+| `CLAUDE.md`（项目根目录） | 低 | 仅在没有 AGENTS.md 时使用 |
+| `~/.config/opencode/AGENTS.md` | 全局 | 用户级规则 |
+| `~/.claude/CLAUDE.md` | 全局回退 | 仅在没有全局 AGENTS.md 时使用 |
+
+**额外指令文件**：`opencode.json` 中的 `instructions` 字段可引用额外文件（支持 glob 和远程 URL）：
+
+```json
+{ "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"] }
+```
+
+**对 GolemBot 的影响**：GolemBot 在 `init` 时生成的 `AGENTS.md` 会被 OpenCode 自动消费 — 不需要额外配置。
+
+---
+
+### 权限系统
+
+OpenCode 的权限通过 `opencode.json` 配置，粒度比 Cursor/Claude Code 更细：
+
+```json
+{
+  "permission": {
+    "*": "allow",
+    "bash": { "*": "ask", "git *": "allow", "rm *": "deny" },
+    "edit": { "*": "allow", "*.env": "deny" }
+  }
+}
+```
+
+三个级别：`"allow"`（自动执行）、`"ask"`（请求批准）、`"deny"`（禁止）
+
+**默认权限**：大多数操作默认为 `"allow"`；只有 `.env` 文件默认为 `"deny"`。**不需要类似 `--dangerously-skip-permissions` 的参数。**
+
+**无头模式状态（v1.1.28）：**
+- `opencode run` 在非交互模式下有已知 bug（[PR #14607](https://github.com/anomalyco/opencode/pull/14607)，尚未合并）
+- Bug 1：`question` 工具在非交互模式下挂起（会话 deny 规则未传播到工具过滤层）
+- Bug 2：配置为 `"ask"` 的权限在非交互模式下自动拒绝，导致工具执行失败
+- **修复（在 PR 中）**：`"ask"` 权限在非交互模式下自动批准；新增 `--no-auto-approve` 标志
+- **当前变通方案**：通过 `OPENCODE_PERMISSION='{"*":"allow"}'` 或 `opencode.json` 将所有权限设为 allow
+
+---
+
+### 代理系统
+
+OpenCode 有内置的代理层级（GolemBot 可通过 `--agent` 参数利用）：
+
+**主代理：**
+- `build` — 默认，完整功能（可读写文件、执行命令）
+- `plan` — 只读模式，分析和规划但不修改文件
+
+**子代理：**
+- `general` — 通用，可并行执行多个任务
+- `explore` — 只读，快速代码搜索
+
+支持自定义代理：通过 `opencode.json` 中的 `agent` 字段或 `.opencode/agents/*.md` 文件定义。
+
+---
+
+### MCP 支持
+
+通过 `opencode.json` 配置（不是 `.cursor/mcp.json` 或 `.claude/mcp.json`）：
+
+```json
+{
+  "mcp": {
+    "my-server": {
+      "type": "local",
+      "command": ["npx", "-y", "my-mcp-command"],
+      "enabled": true
+    },
+    "remote-server": {
+      "type": "remote",
+      "url": "https://mcp.example.com/mcp"
+    }
+  }
+}
+```
+
+支持两种类型：local（命令启动）和 remote（URL + 可选 OAuth）。
+
+---
+
+### 插件系统
+
+OpenCode 提供完整的插件钩子机制（Cursor 和 Claude Code 都没有这个能力）：
+
+```typescript
+export const MyPlugin = async ({ project, client, $ }) => ({
+  "tool.execute.before": async (input, output) => { /* 工具执行前 */ },
+  "tool.execute.after": async (input, output) => { /* 工具执行后 */ },
+  event: async ({ event }) => { /* 事件监听 */ },
+});
+```
+
+插件放在 `.opencode/plugins/`（项目级）或 `~/.config/opencode/plugins/`（全局），也可以作为 npm 包安装。
+
+---
+
+### GitHub Actions 集成
+
+```yaml
+- uses: anomalyco/opencode/github@latest
+  with:
+    model: anthropic/claude-sonnet-4-20250514
+    # prompt: "optional custom prompt"
+    # agent: "build"
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+支持的触发事件：`issue_comment`（/opencode 或 /oc）、`pull_request_review_comment`、`issues`、`pull_request`、`schedule`、`workflow_dispatch`
+
+---
+
+### 配置文件
+
+| 文件 | 位置 | 内容 |
+|------|------|------|
+| `opencode.json` | 项目根目录 | 项目级配置（模型、权限、MCP、代理、工具等） |
+| `opencode.json` | `~/.config/opencode/` | 全局配置 |
+| `auth.json` | `~/.local/share/opencode/` | 提供商凭据 |
+| `.opencode/agents/*.md` | 项目级 | 自定义代理 |
+| `.opencode/plugins/*.ts` | 项目级 | 自定义插件 |
+| `.opencode/tools/*.ts` | 项目级 | 自定义工具 |
+| `.opencode/skills/*/SKILL.md` | 项目级 | 技能定义 |
+
+配置优先级（后者覆盖前者）：远程配置 → 全局 → 项目 → 自定义路径 → `OPENCODE_CONFIG_CONTENT` 环境变量
+
+---
+
+### 已知坑点 & GolemBot 适配说明
+
+1. **冷启动慢（5-10 秒）** — OpenCode 启动时要加载提供商配置、MCP 服务器等，比 Cursor/Claude Code 慢很多。生产环境建议用 `opencode serve` + `--attach` 模式复用服务器实例
+2. **`--format json` 事件结构与 Cursor/Claude Code 完全不同** — 不能复用 `parseStreamLine()` 或 `parseClaudeStreamLine()`；需要独立的 `parseOpenCodeStreamLine()`
+3. **无头模式有已知 bug** — v1.1.28 中，`opencode run` 的 question 工具可能挂起，`"ask"` 权限会自动拒绝。建议显式设置 `permission: "allow"` 作为变通方案
+4. **多提供商认证复杂** — 不像 Cursor/Claude Code 各只需一个环境变量，OpenCode 需要所选提供商对应的 API Key。与 GolemBot 的 `InvokeOpts.apiKey` 集成时，需要知道目标提供商才能设置正确的环境变量名
+5. **技能多路径自动发现** — OpenCode 同时读取 `.opencode/skills/`、`.claude/skills/`、`.agents/skills/`。如果 GolemBot 同时为 Claude Code 和 OpenCode 注入技能，不会冲突（相同的技能只加载一次）
+6. **AGENTS.md 自动消费** — GolemBot 在 init 时生成的 AGENTS.md 会被 OpenCode 自动消费 — 这是正面的兼容性特征
+7. **会话 ID 格式不同** — `ses_XXXXXXXX` 而非 UUID；GolemBot 的会话存储层需要适配
+8. **HTTP Server API 是更好的集成方式** — 相比 CLI spawn 模式，HTTP 模式消除了冷启动，支持中止操作（`POST /session/:id/abort`），可能是更好的引擎实现方式
+9. **`opencode.json` 需要在 init 时生成** — 类似 Cursor 的 `.cursor/cli.json`，OpenCode 的项目配置需要在工作区初始化时生成
+10. **OpenCode 迭代极快** — 截至 2026-03 已到 v1.1.28；API 可能频繁变化，需关注 changelog

--- a/docs/zh/testing/im-playbook.md
+++ b/docs/zh/testing/im-playbook.md
@@ -1,0 +1,302 @@
+# IM 频道集成测试手册
+
+本文档是自动化 `gateway-integration.test.ts` 测试套件的手动测试配套指南。
+涵盖需要真实 bot 账号、实际群聊以及真实 AI 引擎（claude-code 或类似引擎）的
+IM 实际场景。
+
+---
+
+## 前置条件
+
+在运行任何平台测试之前：
+
+1. **启动 bot**，使用真实引擎并配置所有频道：
+   ```bash
+   golem gateway --dir ./my-bot --verbose
+   ```
+   使用 `--verbose` 以便在终端查看每条接收和发送的消息。
+
+2. **golem.yaml 基础配置**（根据测试平台调整）：
+   ```yaml
+   name: golem-test
+   engine: claude-code
+
+   groupChat:
+     groupPolicy: mention-only   # 根据测试章节修改
+     historyLimit: 20
+     maxTurns: 10
+   ```
+
+3. **测试群组设置**：为每个平台创建专用测试群组/频道，包含：
+   - 你（人类测试者）
+   - bot 账号
+   - 可选的第二个人类账号（用于多用户测试）
+
+---
+
+## 平台 A — Telegram
+
+### 设置
+- Bot token: `TELEGRAM_BOT_TOKEN`
+- 创建测试群组，添加 bot
+- 群聊测试需要 bot 为管理员（以读取消息）
+- 可选在 @BotFather 中关闭 privacy mode → bot 可读取所有消息
+
+### 测试用例
+
+#### A-1 · 私聊基本流程
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 打开与 bot 的私聊，发送: `What is 2+2?` | Bot 在 30 秒内回复 |
+| 2 | 发送: `What did I just ask you?` | Bot 回忆起之前的问题（会话连续性） |
+| 3 | 检查终端显示: `received from <you>: "What is 2+2?"` | ✓ verbose 日志 |
+
+#### A-2 · 私聊长回复分割
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 发送: `Write a 500-word essay about clouds` | Bot 发送多条 Telegram 消息，每条 ≤ 4096 字符 |
+| 2 | 验证所有消息按顺序到达 | 无截断，自然分割点 |
+
+#### A-3 · 群组 — mention-only（默认）
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 在测试群中发送: `hello everyone` | Bot 不回复（未被 @mention） |
+| 2 | 检查终端 | 该消息不应有 "received" 日志 |
+| 3 | 发送: `@golem-test hello` | Bot 回复 |
+| 4 | 终端显示 mention 检测 | `session key = telegram:CHAT_ID`（无用户 ID） |
+
+#### A-4 · 群组 — smart 模式
+将配置改为 `groupPolicy: smart`，重启 bot。
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 发送: `We decided to use PostgreSQL for the new project` | Bot 可能回复（smart）或保持沉默 ([PASS]) |
+| 2 | 发送: `@golem-test what database are we using?` | Bot 回答 "PostgreSQL"（使用了群组上下文） |
+| 3 | 终端检查 `[PASS]` 日志 | bot 选择跳过的消息应出现此日志 |
+
+#### A-5 · 群组 — maxTurns 保护
+将配置改为 `maxTurns: 3`, `groupPolicy: always`，重启 bot。
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 连续发送 4 条消息（任意文本） | Bot 回复前 3 条，第 4 条保持沉默 |
+| 2 | 终端显示: `maxTurns (3) reached` | ✓ |
+| 3 | 调用 `POST /reset`，`sessionKey: "telegram:CHAT_ID"` | 群组状态已清除 |
+| 4 | 再发送一条消息 | Bot 重新开始回复 |
+
+#### A-6 · 通过 HTTP API /reset
+```bash
+curl -X POST http://localhost:3000/reset \
+  -H "Content-Type: application/json" \
+  -d '{"sessionKey": "telegram:YOUR_CHAT_ID"}'
+```
+预期结果: `{"ok": true}`。然后发送私聊消息 — bot 不记得之前的对话。
+
+---
+
+## 平台 B — Discord
+
+### 设置
+- Bot token: `DISCORD_BOT_TOKEN`
+- 在 Discord 开发者门户中启用 **Message Content Intent**（读取消息必须）
+- 配置中的 `botName` 是可选的 — mention 检测通过 `<@botId>` 原生工作
+
+### 测试用例
+
+#### B-1 · 私聊基本流程
+与 A-1 相同（验证私聊 session key = `discord:dm-USER_ID`）
+
+#### B-2 · 群组 — 未配置 botName 时的 @mention
+测试 `msg.mentioned` 字段路径（Discord 原生检测）：
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 在频道配置中设置 `botName: ""` 或省略 `botName` | |
+| 2 | 在服务器频道发送: `<@BOT_USER_ID> hello` | Bot 回复（即使没有 botName 也能原生检测 mention） |
+| 3 | 发送: `hello without mention` | Bot 保持沉默（mention-only 模式） |
+
+#### B-3 · 群组 — 配置了 botName 的 @mention
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 在配置中设置 `botName: "golem-test"` | |
+| 2 | 发送: `@golem-test help me` | Bot 回复 |
+| 3 | 终端: prompt 中不应有 `<@userId>` token | 已规范化为 `@golem-test` |
+
+#### B-4 · 消息长度限制（2000 字符）
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 请求: `Write a detailed 3000-character story` | Bot 发送 ≥2 条 Discord 消息，每条 ≤2000 字符 |
+| 2 | 两条消息都到达 | 无 Discord "message too long" 错误 |
+
+#### B-5 · Bot 自回复防护
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 设置 `groupPolicy: smart`，确保 bot 的 Discord 用户名与 `config.name` 匹配 | |
+| 2 | 向 bot 提问；当 bot 回复时，验证 bot 自己的回复不会触发另一次响应 | 无无限循环 |
+
+---
+
+## 平台 C — Slack
+
+### 设置
+- `SLACK_BOT_TOKEN` (Bot User OAuth Token, `xoxb-...`)
+- `SLACK_APP_TOKEN` (Socket Mode token, `xapp-...`)
+- 必须在应用设置中启用 Socket Mode
+- Bot 必须被邀请到测试频道: `/invite @golem-test`
+
+### 测试用例
+
+#### C-1 · 私聊基本流程
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 私聊 bot: `tell me a joke` | Bot 回复 |
+| 2 | 私聊 session key 格式: `slack:DM_CHANNEL_ID:USER_ID` | 检查终端 |
+
+#### C-2 · 频道 — mention-only
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 在测试频道发送: `good morning team` | Bot 保持沉默 |
+| 2 | 发送: `<@BOT_USER_ID> what's the weather like?`（Slack 原生 mention） | Bot 回复 |
+| 3 | 发送: `@golem-test what's 2+2?`（文字 mention） | Bot 回复 |
+
+#### C-3 · 线程回复
+> **注意**: 当前 adapter 在频道中回复，而非线程中。这是已知行为。
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 在线程中 @mention bot | Bot 回复到线程（或顶层，取决于 adapter） |
+
+#### C-4 · 多用户共享群组会话
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 用户 A 说 `@golem-test my name is Alice` | Bot 确认 |
+| 2 | 用户 B 说 `@golem-test what is Alice's name?` | Bot 正确回答（共享会话） |
+| 3 | 终端: 两条消息使用 session key `slack:CHANNEL_ID`（无用户后缀） | ✓ |
+
+#### C-5 · /reset 清除共享群组状态
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 在 C-4 之后重置群组会话 | |
+| 2 | 用户 B 说 `@golem-test what is Alice's name?` | Bot 说不知道（上下文已清除） |
+
+---
+
+## 平台 D — 飞书
+
+### 设置
+- 从飞书开放平台获取 App ID 和 App Secret
+- 启用消息事件权限
+- 将 bot 添加到测试群
+
+### 测试用例
+
+#### D-1 · 私聊基本流程
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 私聊 bot: `你好` | Bot 用同一语言回复 |
+| 2 | Session key 格式: `feishu:USER_OPEN_ID:USER_OPEN_ID`（私聊 chatId = userId） | 检查终端 |
+
+#### D-2 · 群组 — XML 风格 @mention
+飞书使用 `<at user_id="xxx">BotName</at>` 格式进行 mention。
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 在群中 @mention bot（点击 bot 名称） | Bot 回复 |
+| 2 | 终端: 清理后的 mention 文本传给引擎 | `<at...>` 标签已从 prompt 中移除 |
+| 3 | 发送不含 mention 的消息 | Bot 保持沉默（mention-only） |
+
+#### D-3 · 群组 — smart 模式与中文上下文
+切换为 `groupPolicy: smart`。
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 群成员: `我们明天开会讨论新功能` | Bot 观察（可能回复或 [PASS]） |
+| 2 | @mention bot: `刚才说的新功能是什么?` | Bot 从群组上下文中回忆 |
+
+#### D-4 · 附件/图片消息
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 在群中发送图片（无文字） | Bot 忽略（空文本） |
+| 2 | 终端: 无 "received" 日志 | ✓（adapter 应过滤非文本消息） |
+
+---
+
+## 平台 E — 钉钉
+
+### 设置
+- App Key 和 App Secret，Webhook 端点已配置
+- Bot 已添加到测试群（企业内部应用）
+
+### 测试用例
+
+#### E-1 · 私聊基本流程
+与 D-1 模式相同。
+
+#### E-2 · 群组 — @mention 检测
+钉钉使用 `@UserMobile` 或 `@botName` 风格。
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 在群中 @mention bot | Bot 回复 |
+| 2 | 验证消息长度 ≤ 4000 字符 | 钉钉限制得到遵守 |
+
+#### E-3 · 群组会话跨用户共享
+与 C-4 相同，但在钉钉群中。
+
+---
+
+## 平台 F — 企业微信
+
+### 设置
+- Corp ID、Agent ID、Agent Secret
+- Bot 已添加到测试群或应用会话
+
+### 测试用例
+
+#### F-1 · 私聊基本流程
+模式相同，注意 session key 格式。
+
+#### F-2 · 消息长度限制（2048 字符）
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 请求较长的回复 | Bot 在 ≤ 2048 字符处分割（企业微信限制） |
+
+#### F-3 · 群组 — mention-only
+| 步骤 | 操作 | 预期结果 |
+|------|------|----------|
+| 1 | 普通群消息 | Bot 保持沉默 |
+| 2 | @mention bot | Bot 回复 |
+
+---
+
+## 跨平台验证清单
+
+完成平台特定测试后，验证以下行为的一致性：
+
+| 行为 | Telegram | Discord | Slack | 飞书 | 钉钉 | 企业微信 |
+|------|----------|---------|-------|------|------|----------|
+| 私聊 → 每用户 session key | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| 群组 → 共享 session key | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| mention-only: 非 mention 被跳过 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| mention-only: mention 被回复 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| 长回复正确分割 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| /reset 清除会话 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Bot 自回复未被触发 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| 空 @mention 未发送给引擎 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+---
+
+## 已知问题与注意事项
+
+| 问题 | 影响平台 | 解决方法 |
+|------|----------|----------|
+| `botName` 必须与 `config.name` 完全匹配以防止自回复 | 所有 | 在 golem.yaml 中设置 `name: your-bot-username` |
+| Discord: MessageContent intent 必须启用特权权限 | Discord | 在开发者门户中启用 |
+| Slack: Socket Mode 需要单独的 App Token | Slack | 创建 `xapp-...` token |
+| 飞书: 消息事件需要在开放平台订阅 | 飞书 | 启用 `im.message.receive_v1` |
+| 企业微信: 群消息需要将应用配置为"群机器人" | 企业微信 | 检查企业管理员设置 |
+| 钉钉: 出站 webhook 签名必须匹配 | 钉钉 | 在 golem.yaml 的 channels.dingtalk 中设置 `secret` |
+
+---
+
+## 报告问题
+
+如果测试用例失败，请记录：
+1. 接收消息和错误的 verbose 终端日志
+2. IM 平台的原始载荷（如可见）
+3. golem.yaml 的 channels 配置（脱敏 token）
+
+提交 issue: https://github.com/0xranx/AgentForge/issues

--- a/docs/zh/testing/issues.md
+++ b/docs/zh/testing/issues.md
@@ -1,0 +1,176 @@
+# IM 测试手册 — 问题日志
+
+## 平台说明 · 钉钉 Smart 模式平台限制
+
+**发现时间**: 2026-03-04
+**测试阶段**: 钉钉 E-3 Smart mode
+**类型**: 平台限制（非 bug）
+
+### 现象
+在钉钉群中，`groupPolicy: smart` 模式下，bot 无法积累非 @mention 消息的上下文。发送普通群消息（不 @mention bot）时，gateway 日志无任何记录；@mention bot 询问之前群聊内容时，bot 回答"没有相关信息"。
+
+### 根本原因
+钉钉 Stream SDK（`TOPIC_ROBOT` 回调）**平台层面只投递 @mention 消息**给机器人，非 mention 的群消息完全不发给 bot 进程。这是钉钉的安全设计，adapter 层无法绕过（与飞书不同，飞书的过滤是在 adapter 代码里，可以修改；钉钉的过滤在平台侧）。
+
+### 影响
+- `mention-only`：正常工作 ✅
+- `smart`：仅能看到 @mention 消息，无法观察群背景上下文
+- `always`：仅响应 @mention 消息（平台限制等同于 mention-only）
+
+### 建议
+在钉钉文档中注明此平台限制，用户应使用 `mention-only` 模式。
+
+---
+
+## Issue 1 · 跨引擎 session ID 污染导致 opencode 挂起
+
+**发现时间**: 2026-03-03
+**测试阶段**: Telegram A-1 私聊基本流程
+**严重级别**: High
+
+### 现象
+切换引擎（`claude-code` → `opencode`）后，`.golem/sessions.json` 里残留了旧引擎的 session ID（UUID 格式，如 `0c6342a4-7270-4300-90bb-b86b0a407fde`）。下次调用 opencode 时，框架把这个 ID 传给 `opencode --session <id>`，opencode 找不到对应 session，进程卡住不返回，既不报错也不超时（在 5 分钟观察窗口内）。
+
+### 复现步骤
+1. 用 `engine: claude-code` 启动 gateway 并发几条消息（产生 session 记录）
+2. 改为 `engine: opencode`，不清除 `.golem/sessions.json`
+3. 发送新消息 → gateway 显示 "received" 日志但无回复，opencode 进程悬挂
+
+### 根本原因
+`doChat()` 里 `loadSession()` 取出的 session ID 是上一引擎格式的，直接传给新引擎的 `--session` 参数，新引擎无法 resume，又不返回 error event，自动 fallback 逻辑无法触发。
+
+### 临时解决方案
+切换引擎前手动删除 `.golem/sessions.json`，或调用 `POST /reset`。
+
+### 修复方案（已实施）
+`SessionEntry` 新增 `engineType` 字段。`loadSession` 时若存储的 `engineType` 与当前引擎不符，直接返回 `undefined`（相当于全新 session），让引擎从零开始而不是尝试 resume 一个外来 session ID。`saveSession` 同步写入当前 `engineType`。
+
+相关文件：`src/session.ts`（`SessionEntry` 接口、`loadSession`、`saveSession`）；`src/index.ts`（调用处传入 `engineType`）。
+
+---
+
+---
+
+## Issue 3 · Telegram 群 @mention 消息不被投递（privacy mode 默认 ON）
+
+**发现时间**: 2026-03-03
+**测试阶段**: Telegram A-3 群组 mention-only
+**严重级别**: High（群聊功能完全失效）
+
+### 现象
+Telegram bot 默认 privacy mode 为 ON（`can_read_all_group_messages: false`）。此模式下，Telegram **只**投递命令（`/start` 等），@mention 消息根本不会发送给 bot——grammy 长轮询收不到 update，handler 自然不触发。验证：`/start` 可收到，`@golemsy_bot hello` 收不到。
+
+### 根本原因
+Telegram Bot API 行为：privacy mode ON + bot 非群管理员 = 只投递 `/commands`，@mention 被过滤。
+
+### 修复方案
+1. **关闭 privacy mode**（推荐）：@BotFather → `/setprivacy` → 选 bot → Disable → 重启 bot 后生效
+2. 将 bot 设为群管理员
+
+### 文档需补充
+`docs/channels/telegram.md` 应明确说明：群聊使用时必须通过 @BotFather 关闭 privacy mode，否则 @mention 不会被投递。
+
+---
+
+## Issue 4 · Telegram 群 @mention 不触发回复（双重 bug）
+
+**发现时间**: 2026-03-03
+**测试阶段**: Telegram A-3 群组 mention-only
+**严重级别**: High（群聊 @mention 功能完全失效）
+**状态**: ✅ 已修复
+
+### 现象
+关闭 privacy mode 并重新邀请 bot 后，群里发 `@golemsy_bot hello` 仍无回复，gateway 日志无任何处理记录。
+
+### 根本原因（两处 bug 叠加）
+
+**Bug 1**：`src/channels/telegram.ts` 使用 `bot.on('message:text', ...)` 注册处理器。经测试确认，grammy 的 `message:text` 过滤器对含 mention 实体的群消息**不触发**（`message` handler 触发，`message:text` 不触发）。因此群 @mention 消息根本不进入处理器。
+
+**Bug 2**：adapter 调用 `onMessage()` 时未传 `mentioned: true`，导致 `gateway.ts` 的第二轮 mention 检查（`detectMention(msg.text, config.name)`）也失败——因为 adapter 已经 strip 了 `@botUsername`，且 `config.name`（`golem-test`）与 Telegram 机器人用户名（`golemsy_bot`）不同。
+
+### 修复方案
+1. 将 `bot.on('message:text', ...)` 改为 `bot.on('message', ...)`，在 handler 内手动判断 `if (!message?.text) return`
+2. 当群消息被 @mention 时，`onMessage()` 的 payload 里加上 `mentioned: true`
+
+两处修复均已提交到 `src/channels/telegram.ts`。
+
+---
+
+## Issue 5 · Slack/飞书/钉钉群 @mention 消息被 gateway 静默丢弃
+
+**发现时间**: 2026-03-03
+**测试阶段**: Slack C-2 频道 mention-only
+**严重级别**: High（群聊 @mention 功能完全失效）
+**影响范围**: Slack、飞书、钉钉三个 adapter
+**状态**: ✅ 已修复
+
+### 现象
+在 Slack 频道里 `@GolemBot what's 2+2?`，bot 无回复，gateway 日志无任何 "received" 记录。通过临时 debug log 确认：`app_mention` 事件确实到达了 Bolt 的事件处理器，但 `onMessage` 之后没有产生任何日志。
+
+### 根本原因
+Slack adapter 的 `app_mention` 处理器在调用 `onMessage` 前已把 `<@BOT_ID>` strip 掉，但没有设置 `mentioned: true`。gateway 的 mention 检查逻辑为：
+
+```typescript
+const mentioned = detectMention(msg.text, config.name) || !!msg.mentioned;
+if (gc.groupPolicy === 'mention-only' && !mentioned) return;
+```
+
+- `detectMention(strippedText, 'golem-test')` → `false`（文本中已无 @token）
+- `!!msg.mentioned` → `false`（adapter 未设置）
+- 结果：`mentioned-only` 模式下直接 `return`，消息被静默丢弃
+
+**同样问题存在于**：
+- 飞书 adapter：群消息在 adapter 内已过滤（仅转发被 @mention 的消息），但 `mentioned` 字段未设置
+- 钉钉 adapter：平台本身只投递 @mention 消息，但 `mentioned` 字段未设置
+
+### 修复方案
+在 `app_mention` / 飞书群消息 / 钉钉群消息的 `onMessage` payload 中加入 `mentioned: true`：
+- `src/channels/slack.ts`: `onMessage({ ..., mentioned: true })`
+- `src/channels/feishu.ts`: `onMessage({ ..., mentioned: chatType === 'group' ? true : undefined })`
+- `src/channels/dingtalk.ts`: `onMessage({ ..., mentioned: isGroup ? true : undefined })`
+
+---
+
+## Issue 2 · 长回复"批量投递"体验差
+
+**发现时间**: 2026-03-03
+**测试阶段**: Telegram A-2 私聊长回复分割
+**严重级别**: Medium（UX 问题，非功能 bug）
+**状态**: ✅ 已修复
+
+### 现象
+生成 3000 字回复时，用户等待约 60 秒看不到任何反馈，引擎生成完毕后 5 条消息几乎同时到达。
+
+### 根本原因
+`handleMessage` 先将引擎全部 text 事件累积成完整 `reply` 字符串，完成后才 `splitMessage` + 逐 chunk `adapter.reply()`。对 IM 平台不支持 streaming 这一设计决策是正确的，但缺少中间反馈。
+
+### 修复方案（已实施）
+在 `ChannelAdapter` 接口新增可选 `typing?(msg): Promise<void>` 方法。`gateway.ts` 的 `handleMessage` 在调用 AI 前立即触发一次 typing，并每 4 秒刷新（Telegram 的 typing 动作 ~5s 过期），直到 AI 回复完毕（`finally` 块清除 interval）。
+
+Telegram adapter 实现：`bot.api.sendChatAction(chatId, 'typing')`。其他平台可按需实现同一接口：
+- Slack：`chat.postMessage` ephemeral 或 reaction emoji
+- Discord：`channel.sendTyping()`
+
+---
+
+## Issue 6 · Codex 引擎未注入 skills 到 `.agents/skills/` 目录
+
+**发现时间**: 2026-03-04
+**类型**: 功能缺失
+**严重级别**: Medium
+**状态**: ✅ 已修复
+
+### 现象
+Codex CLI 原生支持 `.agents/skills/` 目录（与 Claude Code 的 `.claude/skills/`、Cursor 的 `.cursor/skills/` 同类机制），但 GolemBot 的 `CodexEngine` 未将 skills symlink 到该目录。当前仅依赖 `workspace.ts` 生成的 `AGENTS.md` 文件传递 skill 信息。
+
+### 影响
+- Codex 无法通过原生 skill 发现机制（progressive disclosure）加载 GolemBot skills
+- Skill 内的附带文件（脚本、模板、参考文档）不会被 Codex 读到，只有 `AGENTS.md` 中的文本描述可见
+
+### 参考
+- Codex skills 官方文档: https://developers.openai.com/codex/concepts/customization/
+- Codex skills 目录约定: 全局 `~/.agents/skills/`，项目级 `.agents/skills/`
+- 每个 skill 为一个包含 `SKILL.md` 的目录，支持 frontmatter（`name`, `description`）
+
+### 修复方案（已实施）
+在 `src/engines/codex.ts` 的 `injectCodexSkills()` 中，仿照其他引擎的实现，将 `skills/` 目录 symlink 到 `.agents/skills/`。每次 invoke 时清理旧 symlink 并重建，保持与 skills 目录同步。


### PR DESCRIPTION
## Summary

Translates 9 documentation files to Chinese under `docs/zh/`:

### Reference (7 files)
- `architecture.md` — 架构设计
- `coding-cli-cursor.md` — Cursor Agent CLI
- `coding-cli-claude-code.md` — Claude Code CLI
- `coding-cli-opencode.md` — OpenCode CLI
- `coding-cli-codex.md` — Codex CLI
- `coding-cli-comparison.md` — 四引擎对比矩阵
- `coding-cli-docs.md` — CLI 实战笔记索引

### Testing (2 files)
- `im-playbook.md` — IM 频道集成测试手册
- `issues.md` — 测试问题日志

### Translation conventions
- Code blocks, CLI commands, config keys, and URLs preserved in English
- Technical terms follow existing `docs/zh/` conventions (engine=引擎, session=会话, skill=技能, etc.)
- Markdown formatting matches source files