### PR TITLE
fix: add missing listHistoryFiles and readHistory exports for golembot log

### DIFF
--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -7,8 +7,10 @@ import {
   clearSession,
   countSessions,
   getHistoryPath,
+  listHistoryFiles,
   loadSession,
   pruneExpiredSessions,
+  readHistory,
   saveSession,
 } from '../session.js';
 
@@ -255,6 +257,46 @@ describe('session', () => {
       expect(await countSessions(dir)).toBe(2);
       await clearSession(dir, 'user:a');
       expect(await countSessions(dir)).toBe(1);
+    });
+  });
+
+  describe('listHistoryFiles', () => {
+    it('returns empty array when no history', async () => {
+      expect(await listHistoryFiles(dir)).toEqual([]);
+    });
+
+    it('lists session keys from history files', async () => {
+      await appendHistory(dir, { ts: new Date().toISOString(), sessionKey: 'user:alice', role: 'user', content: 'hi' });
+      await appendHistory(dir, { ts: new Date().toISOString(), sessionKey: 'user:bob', role: 'user', content: 'hello' });
+      const keys = await listHistoryFiles(dir);
+      expect(keys).toContain('user:alice');
+      expect(keys).toContain('user:bob');
+      expect(keys.length).toBe(2);
+    });
+  });
+
+  describe('readHistory', () => {
+    it('returns empty array for non-existent session', async () => {
+      expect(await readHistory(dir, 'nonexistent')).toEqual([]);
+    });
+
+    it('reads all entries', async () => {
+      await appendHistory(dir, { ts: '2026-01-01T00:00:00Z', sessionKey: 'test', role: 'user', content: 'hello' });
+      await appendHistory(dir, { ts: '2026-01-01T00:00:01Z', sessionKey: 'test', role: 'assistant', content: 'hi back' });
+      const entries = await readHistory(dir, 'test');
+      expect(entries.length).toBe(2);
+      expect(entries[0].role).toBe('user');
+      expect(entries[1].role).toBe('assistant');
+    });
+
+    it('respects limit parameter', async () => {
+      for (let i = 0; i < 10; i++) {
+        await appendHistory(dir, { ts: `2026-01-01T00:00:${String(i).padStart(2, '0')}Z`, sessionKey: 'limited', role: 'user', content: `msg ${i}` });
+      }
+      const entries = await readHistory(dir, 'limited', 3);
+      expect(entries.length).toBe(3);
+      expect(entries[0].content).toBe('msg 7');
+      expect(entries[2].content).toBe('msg 9');
     });
   });
 });

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,5 +1,5 @@
-import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { appendFile, mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { join, basename } from 'node:path';
 
 const GOLEM_DIR = '.golem';
 const SESSION_FILE = 'sessions.json';
@@ -102,6 +102,37 @@ export async function pruneExpiredSessions(dir: string, maxAgeDays: number): Pro
 export async function countSessions(dir: string): Promise<number> {
   const store = await readStore(dir);
   return Object.keys(store).length;
+}
+
+export async function listHistoryFiles(dir: string): Promise<string[]> {
+  const histDir = join(dir, GOLEM_DIR, 'history');
+  try {
+    const files = await readdir(histDir);
+    return files.filter((f) => f.endsWith('.jsonl')).map((f) => f.replace(/\.jsonl$/, ''));
+  } catch {
+    return [];
+  }
+}
+
+export async function readHistory(
+  dir: string,
+  sessionKey: string,
+  limit?: number,
+): Promise<HistoryEntry[]> {
+  const path = historyPath(dir, sessionKey);
+  try {
+    const raw = await readFile(path, 'utf-8');
+    const lines = raw
+      .split('\n')
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l) as HistoryEntry);
+    if (limit && limit > 0) {
+      return lines.slice(-limit);
+    }
+    return lines;
+  } catch {
+    return [];
+  }
 }
 
 export async function appendHistory(dir: string, entry: HistoryEntry): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes `golembot log` command which fails at runtime because `listHistoryFiles` and `readHistory` are imported from `session.ts` but were never implemented.

### Problem

`cli.ts` (line 825) does:
```typescript
const { listHistoryFiles, readHistory } = await import('./session.js');
```

But `session.ts` only exports `appendHistory` and `getHistoryPath` — no read functions exist. Running `golembot log` throws:
```
SyntaxError: The requested module does not provide an export named 'listHistoryFiles'
```

### Fix

Add two functions to `session.ts`:

- **`listHistoryFiles(dir)`** — reads `.golem/history/` directory, returns session keys extracted from `.jsonl` filenames
- **`readHistory(dir, sessionKey, limit?)`** — reads and parses JSONL history file, supports tail limiting (returns last N entries)

### Tests

5 new test cases covering:
- Empty history directory
- Listing multiple session keys
- Reading entries for non-existent session
- Reading all entries
- Respecting limit parameter (tail behavior)

All 30 session tests pass.