### PR TITLE
feat(provider): ProviderStore + provider CLI (list/init/add/remove/set-current)

### DIFF
--- a/src/__tests__/provider.test.ts
+++ b/src/__tests__/provider.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ProviderStore } from '../provider.js';
+
+describe('ProviderStore', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'golem-provider-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns empty when providers.json does not exist', async () => {
+    const store = new ProviderStore(dir);
+    const data = await store.read();
+    expect(data.providers).toEqual({});
+    expect(data.strategy).toBeUndefined();
+  });
+
+  it('reads and writes providers', async () => {
+    const store = new ProviderStore(dir);
+    const data = {
+      currentProviderId: 'primary',
+      strategy: 'single' as const,
+      providers: {
+        primary: {
+          id: 'primary',
+          engine: 'claude-code',
+          model: 'claude-sonnet-4',
+          apiKey: '${ANTHROPIC_API_KEY}',
+          priority: 0,
+        },
+      },
+    };
+    await store.write(data);
+    const read = await store.read();
+    expect(read.currentProviderId).toBe('primary');
+    expect(read.strategy).toBe('single');
+    expect(read.providers.primary.engine).toBe('claude-code');
+    expect(read.providers.primary.model).toBe('claude-sonnet-4');
+  });
+
+  it('recordSuccess resets consecutive failures', async () => {
+    const store = new ProviderStore(dir);
+    await store.write({
+      providers: {
+        p1: {
+          id: 'p1',
+          engine: 'opencode',
+          consecutiveFailures: 2,
+          health: 'degraded',
+        },
+      },
+    });
+    await store.recordSuccess('p1');
+    const data = await store.read();
+    expect(data.providers.p1.consecutiveFailures).toBe(0);
+    expect(data.providers.p1.health).toBe('healthy');
+  });
+
+  it('recordFailure increments consecutive failures and marks unhealthy at threshold', async () => {
+    const store = new ProviderStore(dir);
+    await store.write({
+      circuitBreakerThreshold: 2,
+      providers: {
+        p1: { id: 'p1', engine: 'codex' },
+      },
+    });
+    await store.recordFailure('p1');
+    let data = await store.read();
+    expect(data.providers.p1.consecutiveFailures).toBe(1);
+    expect(data.providers.p1.health).toBeUndefined();
+
+    await store.recordFailure('p1');
+    data = await store.read();
+    expect(data.providers.p1.consecutiveFailures).toBe(2);
+    expect(data.providers.p1.health).toBe('unhealthy');
+  });
+});
+
+describe('ProviderStore availability checks', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'golem-provider-availability-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('treats healthy providers as available', () => {
+    const store = new ProviderStore(dir);
+    const available = store.isProviderAvailable(
+      { id: 'p1', engine: 'claude-code', health: 'healthy' },
+      { providers: {}, circuitBreakerCooldownMs: 60_000 },
+    );
+    expect(available).toBe(true);
+  });
+
+  it('treats unhealthy providers as unavailable during cooldown', () => {
+    const store = new ProviderStore(dir);
+    const available = store.isProviderAvailable(
+      {
+        id: 'p1',
+        engine: 'claude-code',
+        health: 'unhealthy',
+        lastFailureAt: Date.now(),
+      },
+      { providers: {}, circuitBreakerCooldownMs: 60_000 },
+    );
+    expect(available).toBe(false);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -674,6 +674,168 @@ skill
     await generateAgentsMd(dir, skills);
   });
 
+// ── Provider Control Plane (Issue #4) ────────────────────
+
+const provider = program
+  .command('provider')
+  .description('Manage AI providers (engine/model/API key) for failover and switching');
+
+provider
+  .command('list')
+  .description('List configured providers')
+  .option('-d, --dir <dir>', 'assistant directory', '.')
+  .option('--json', 'output JSON (agent-friendly)')
+  .action(async (opts: { dir: string; json?: boolean }) => {
+    const dir = resolve(opts.dir);
+    const { ProviderStore } = await import('./provider.js');
+    const store = new ProviderStore(dir);
+    const data = await store.read();
+
+    if (opts.json) {
+      console.log(JSON.stringify(data));
+      return;
+    }
+
+    const ids = Object.keys(data.providers);
+    if (ids.length === 0) {
+      console.log('\n(no providers configured — using golem.yaml engine/model)\n');
+      console.log('Create providers with: golembot provider init');
+      return;
+    }
+
+    console.log(`\nProviders (strategy: ${data.strategy ?? 'single'}):\n`);
+    for (const id of ids) {
+      const p = data.providers[id];
+      const cur = data.currentProviderId === id ? ' *' : '';
+      const health = p.health ? ` [${p.health}]` : '';
+      console.log(`  ${id}${cur}${health}`);
+      console.log(`    engine: ${p.engine}  model: ${p.model ?? '(default)'}`);
+    }
+    console.log();
+  });
+
+provider
+  .command('init')
+  .description('Create providers.json from golem.yaml (adds current engine/model as first provider)')
+  .option('-d, --dir <dir>', 'assistant directory', '.')
+  .action(async (opts: { dir: string }) => {
+    const dir = resolve(opts.dir);
+    const { loadConfig } = await import('./workspace.js');
+    const { ProviderStore } = await import('./provider.js');
+
+    const config = await loadConfig(dir);
+    const store = new ProviderStore(dir);
+    const existing = await store.read();
+
+    if (Object.keys(existing.providers).length > 0) {
+      console.log('providers.json already has providers. Use provider add to add more.');
+      return;
+    }
+
+    const defaultApiKeyByEngine: Record<string, string> = {
+      'claude-code': '${ANTHROPIC_API_KEY}',
+      codex: '${OPENAI_API_KEY}',
+      cursor: '${CURSOR_API_KEY}',
+      opencode: '${OPENROUTER_API_KEY}',
+    };
+
+    const defaultId = 'primary';
+    await store.write({
+      currentProviderId: defaultId,
+      strategy: 'single',
+      providers: {
+        [defaultId]: {
+          id: defaultId,
+          engine: config.engine,
+          model: config.model,
+          apiKey: defaultApiKeyByEngine[config.engine] ?? undefined,
+          priority: 0,
+        },
+      },
+    });
+
+    console.log(`\n✅ Created .golem/providers.json with provider "${defaultId}"`);
+    console.log(`   engine: ${config.engine}  model: ${config.model ?? '(default)'}`);
+    console.log('\nEdit .golem/providers.json to add more providers or set apiKey.\n');
+  });
+
+provider
+  .command('add <id>')
+  .description('Add a provider')
+  .requiredOption('-e, --engine <engine>', 'engine (cursor | claude-code | opencode | codex)')
+  .option('-m, --model <model>', 'model string')
+  .option('--api-key <key>', 'API key or ${ENV_VAR}')
+  .option('-p, --priority <n>', 'failover priority (lower = first)', '0')
+  .option('-d, --dir <dir>', 'assistant directory', '.')
+  .action(async (id: string, opts: { engine: string; model?: string; apiKey?: string; priority: string; dir: string }) => {
+    const dir = resolve(opts.dir);
+    const { ProviderStore } = await import('./provider.js');
+    const store = new ProviderStore(dir);
+    const data = await store.read();
+
+    if (data.providers[id]) {
+      console.error(`❌ Provider "${id}" already exists`);
+      process.exit(1);
+    }
+
+    data.providers[id] = {
+      id,
+      engine: opts.engine,
+      model: opts.model,
+      apiKey: opts.apiKey,
+      priority: Number(opts.priority),
+    };
+    if (!data.currentProviderId) data.currentProviderId = id;
+    await store.write(data);
+    console.log(`✅ Added provider "${id}" (${opts.engine}${opts.model ? ` / ${opts.model}` : ''})`);
+  });
+
+provider
+  .command('remove <id>')
+  .description('Remove a provider')
+  .option('-d, --dir <dir>', 'assistant directory', '.')
+  .action(async (id: string, opts: { dir: string }) => {
+    const dir = resolve(opts.dir);
+    const { ProviderStore } = await import('./provider.js');
+    const store = new ProviderStore(dir);
+    const data = await store.read();
+
+    if (!data.providers[id]) {
+      console.error(`❌ Provider "${id}" not found`);
+      process.exit(1);
+    }
+
+    delete data.providers[id];
+
+    if (data.currentProviderId === id) {
+      const remainingIds = Object.keys(data.providers);
+      data.currentProviderId = remainingIds[0];
+    }
+
+    await store.write(data);
+    console.log(`✅ Removed provider "${id}"`);
+  });
+
+provider
+  .command('set-current <id>')
+  .description('Set the current provider (for single strategy)')
+  .option('-d, --dir <dir>', 'assistant directory', '.')
+  .action(async (id: string, opts: { dir: string }) => {
+    const dir = resolve(opts.dir);
+    const { ProviderStore } = await import('./provider.js');
+    const store = new ProviderStore(dir);
+    const data = await store.read();
+
+    if (!data.providers[id]) {
+      console.error(`❌ Provider "${id}" not found`);
+      process.exit(1);
+    }
+
+    data.currentProviderId = id;
+    await store.write(data);
+    console.log(`✅ Current provider set to "${id}"`);
+  });
+
 const fleet = program.command('fleet').description('Manage and view all running GolemBot instances');
 
 fleet

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,0 +1,132 @@
+/**
+ * ProviderStore — SSOT for provider configuration.
+ *
+ * PR A scope: provider persistence and CLI management only.
+ * Runtime integration (ProviderBroker, engine env resolution) is in PR B.
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const GOLEM_DIR = '.golem';
+const PROVIDERS_FILE = 'providers.json';
+
+/** Strategy for selecting provider: single or failover by priority */
+export type ProviderStrategy = 'single' | 'priority_failover';
+
+/** Health status of a provider */
+export type ProviderHealth = 'healthy' | 'degraded' | 'unhealthy' | 'unknown';
+
+export interface ProviderDef {
+  id: string;
+  /** Engine type: cursor, claude-code, opencode, codex */
+  engine: string;
+  /** Model string (e.g. claude-sonnet-4-20250514, openrouter/anthropic/...) */
+  model?: string;
+  /** API key or ${ENV_VAR} reference */
+  apiKey?: string;
+  /** Custom endpoint URL (for some engines) */
+  endpoint?: string;
+  /** Priority for failover (lower = higher priority). Default: 0 */
+  priority?: number;
+  /** Current health. Managed by ProviderStore. */
+  health?: ProviderHealth;
+  /** Last failure timestamp (unix ms). Used for circuit breaker. */
+  lastFailureAt?: number;
+  /** Consecutive failure count. Reset on success. */
+  consecutiveFailures?: number;
+  /** Extra env vars for this provider (e.g. OPENROUTER_API_KEY) */
+  env?: Record<string, string>;
+}
+
+export interface ProviderStoreData {
+  /** Current active provider id (for single strategy) */
+  currentProviderId?: string;
+  /** Strategy: single = use currentProviderId; priority_failover = try by priority */
+  strategy?: ProviderStrategy;
+  /** Provider definitions, keyed by id */
+  providers: Record<string, ProviderDef>;
+  /** Optional: circuit breaker — min failures before marking unhealthy */
+  circuitBreakerThreshold?: number;
+  /** Optional: cooldown ms before retrying unhealthy provider */
+  circuitBreakerCooldownMs?: number;
+}
+
+function providersPath(dir: string): string {
+  return join(dir, GOLEM_DIR, PROVIDERS_FILE);
+}
+
+/**
+ * ProviderStore — Single Source of Truth for provider configuration.
+ * Persists to .golem/providers.json.
+ */
+export class ProviderStore {
+  constructor(private readonly dir: string) {}
+
+  async read(): Promise<ProviderStoreData> {
+    try {
+      const raw = await readFile(providersPath(this.dir), 'utf-8');
+      const data = JSON.parse(raw) as ProviderStoreData;
+      if (!data.providers || typeof data.providers !== 'object') {
+        return { providers: {} };
+      }
+      return {
+        currentProviderId: data.currentProviderId,
+        strategy: data.strategy ?? 'single',
+        providers: data.providers,
+        circuitBreakerThreshold: data.circuitBreakerThreshold,
+        circuitBreakerCooldownMs: data.circuitBreakerCooldownMs,
+      };
+    } catch {
+      return { providers: {} };
+    }
+  }
+
+  async write(data: ProviderStoreData): Promise<void> {
+    const golemDir = join(this.dir, GOLEM_DIR);
+    await mkdir(golemDir, { recursive: true });
+    await writeFile(
+      providersPath(this.dir),
+      JSON.stringify(data, null, 2) + '\n',
+      'utf-8',
+    );
+  }
+
+  /** Record a successful invocation — reset consecutive failures for this provider */
+  async recordSuccess(providerId: string): Promise<void> {
+    const data = await this.read();
+    const p = data.providers[providerId];
+    if (p) {
+      p.consecutiveFailures = 0;
+      p.health = 'healthy';
+      await this.write(data);
+    }
+  }
+
+  /** Record a failure — increment consecutive failures, optionally mark unhealthy */
+  async recordFailure(providerId: string): Promise<void> {
+    const data = await this.read();
+    const p = data.providers[providerId];
+    if (!p) return;
+
+    p.lastFailureAt = Date.now();
+    p.consecutiveFailures = (p.consecutiveFailures ?? 0) + 1;
+
+    const threshold = data.circuitBreakerThreshold ?? 3;
+    if (p.consecutiveFailures >= threshold) {
+      p.health = 'unhealthy';
+    }
+
+    await this.write(data);
+  }
+
+  /** Check if provider is available (not in cooldown, not unhealthy) */
+  isProviderAvailable(p: ProviderDef, data: ProviderStoreData): boolean {
+    if (p.health === 'unhealthy') {
+      const cooldown = data.circuitBreakerCooldownMs ?? 60_000; // 1 min default
+      const elapsed = Date.now() - (p.lastFailureAt ?? 0);
+      return elapsed >= cooldown;
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary

PR A from the [#5 review](https://github.com/0xranx/golembot/pull/5#pullrequestreview-) — scoped to store + CLI only, no runtime engine integration.

- **`src/provider.ts`** — `ProviderStore` class: read/write `.golem/providers.json`, `recordSuccess`, `recordFailure`, `isProviderAvailable` (circuit breaker)
- **`src/cli.ts`** — `provider` subcommands: `list`, `init`, `add`, `remove`, `set-current`
- **`src/__tests__/provider.test.ts`** — 6 unit tests for `ProviderStore`

### Fixes from PR #5 review

- `provider init` now sets engine-appropriate API key placeholder (`${ANTHROPIC_API_KEY}`, `${OPENAI_API_KEY}`, `${CURSOR_API_KEY}`, `${OPENROUTER_API_KEY}`) instead of always hardcoding `${ANTHROPIC_API_KEY}`
- Added `provider remove` command (was missing from PR #5)

### Not in this PR (PR B)

- `ProviderBroker` runtime resolution
- Engine adapter integration (`resolveInvokeEnv`)
- Health tracking during `chat()` calls

## Test plan

- [ ] `pnpm run build` — TypeScript compiles cleanly
- [ ] `pnpm run test` — all 6 provider tests pass
- [ ] `golembot provider init` — creates `.golem/providers.json` with correct engine-specific API key placeholder
- [ ] `golembot provider add backup -e opencode -m openrouter/anthropic/claude-sonnet-4` — adds provider
- [ ] `golembot provider list` — shows providers with health/current marker
- [ ] `golembot provider remove backup` — removes provider, reassigns currentProviderId if needed
- [ ] `golembot provider set-current <id>` — updates currentProviderId

