### PR TITLE
fix: support WeCom SDK callback bodies

### DIFF
--- a/src/__tests__/wecom.test.ts
+++ b/src/__tests__/wecom.test.ts
@@ -149,6 +149,55 @@ describe('WecomAdapter', () => {
       const msg: ChannelMessage = onMessageMock.mock.calls[0][0];
       expect(msg.text).toBe('(image)');
     });
+
+    it('parses SDK callback fields from frame.body and keeps raw frame', () => {
+      const textHandler = handlers.get('message.text')!;
+      const frame = {
+        event: 'message.text',
+        body: {
+          msgid: 'body-msg-1',
+          from: { userid: 'user-body-1' },
+          from_name: 'Body User',
+          chattype: 'group',
+          chatid: 'group-body-1',
+          text: { content: 'Hello from body' },
+          mentioned: true,
+        },
+      };
+
+      textHandler(frame);
+
+      expect(onMessageMock).toHaveBeenCalledOnce();
+      const msg: ChannelMessage = onMessageMock.mock.calls[0][0];
+      expect(msg.senderId).toBe('user-body-1');
+      expect(msg.senderName).toBe('Body User');
+      expect(msg.chatId).toBe('group-body-1');
+      expect(msg.chatType).toBe('group');
+      expect(msg.text).toBe('Hello from body');
+      expect(msg.messageId).toBe('body-msg-1');
+      expect(msg.mentioned).toBe(true);
+      expect(msg.raw).toBe(frame);
+    });
+
+    it('falls back to senderId as chatId for single-chat SDK callbacks', () => {
+      const textHandler = handlers.get('message.text')!;
+      textHandler({
+        body: {
+          msgId: 'body-msg-2',
+          userId: 'user-body-2',
+          chatType: 'single',
+          content: { text: 'DM via body' },
+        },
+      });
+
+      expect(onMessageMock).toHaveBeenCalledOnce();
+      const msg: ChannelMessage = onMessageMock.mock.calls[0][0];
+      expect(msg.senderId).toBe('user-body-2');
+      expect(msg.chatId).toBe('user-body-2');
+      expect(msg.chatType).toBe('dm');
+      expect(msg.text).toBe('DM via body');
+      expect(msg.messageId).toBe('body-msg-2');
+    });
   });
 
   describe('reply', () => {

--- a/src/channels/wecom.ts
+++ b/src/channels/wecom.ts
@@ -49,7 +49,8 @@ export class WecomAdapter implements ChannelAdapter {
   }
 
   private handleFrame(frame: any, onMessage: (msg: ChannelMessage) => void, fallbackText?: string): void {
-    const msgId: string | undefined = frame.msgId || frame.message_id;
+    const body = frame?.body ?? frame;
+    const msgId: string | undefined = body.msgid || body.msgId || body.message_id;
     if (msgId) {
       if (this.seenMsgIds.has(msgId)) return;
       this.seenMsgIds.add(msgId);
@@ -59,20 +60,28 @@ export class WecomAdapter implements ChannelAdapter {
       }
     }
 
-    const text = frame.content?.text || frame.text || fallbackText || '';
+    const text =
+      body.text?.content ||
+      body.content?.text ||
+      (typeof body.text === 'string' ? body.text : undefined) ||
+      fallbackText ||
+      '';
     if (!text) return;
 
-    const isGroup = frame.chatType === 'group' || frame.chat_type === 'group';
+    const senderId = body.from?.userid || body.userId || (typeof body.from === 'string' ? body.from : '') || '';
+    const chatType = body.chattype || body.chatType || body.chat_type;
+    const isGroup = chatType === 'group';
+    const chatId = body.chatid || body.chatId || body.conversation_id || (!isGroup ? senderId : '');
 
     const channelMsg: ChannelMessage = {
       channelType: 'wecom',
-      senderId: frame.userId || frame.from || '',
-      senderName: frame.userName || frame.from_name,
-      chatId: frame.chatId || frame.conversation_id || '',
+      senderId,
+      senderName: body.userName || body.from_name,
+      chatId,
       chatType: isGroup ? 'group' : 'dm',
       text,
       messageId: msgId,
-      mentioned: frame.mentioned,
+      mentioned: body.mentioned,
       raw: frame,
     };
 


### PR DESCRIPTION
## Summary
- parse WeCom inbound callbacks from `frame.body ?? frame` so current SDK payloads are converted into usable channel messages
- normalize message id, sender, chat type, and single-chat fallback chat id handling while preserving the original raw frame for replies
- add regression tests for SDK body callbacks and single-chat chatId fallback behavior

## Verification
- pnpm exec vitest run src/__tests__/wecom.test.ts
- pnpm build