### PR TITLE
fix: isolate Slack sessions by thread

### DIFF
--- a/src/__tests__/channel.test.ts
+++ b/src/__tests__/channel.test.ts
@@ -25,6 +25,20 @@ describe('buildSessionKey', () => {
     };
     expect(buildSessionKey(msg)).toBe('dingtalk:conv_single:user001');
   });
+
+  it('uses thread-specific key for slack dm threads', () => {
+    const msg: ChannelMessage = {
+      channelType: 'slack',
+      senderId: 'U001',
+      chatId: 'D001',
+      chatType: 'dm',
+      text: 'hello in thread',
+      threadId: '1742920000.123456',
+      raw: {},
+    };
+
+    expect(buildSessionKey(msg)).toBe('slack:D001:U001:thread:1742920000.123456');
+  });
 });
 
 describe('stripMention', () => {

--- a/src/__tests__/gateway.test.ts
+++ b/src/__tests__/gateway.test.ts
@@ -12,6 +12,7 @@ import {
   groupHistories,
   groupLastActivity,
   groupTurnCounters,
+  handleMessage,
   purgeIdleGroups,
   requireFields,
   resolveGroupChatConfig,
@@ -430,6 +431,125 @@ describe('GROUP_TURN_RESET_MS', () => {
     // Simulate the reset condition: Date.now() - lastActivity > GROUP_TURN_RESET_MS
     expect(now - oneHourAgo > GROUP_TURN_RESET_MS).toBe(true); // → reset
     expect(now - justNow > GROUP_TURN_RESET_MS).toBe(false); // → no reset
+  });
+});
+
+describe('Slack thread conversation keys', () => {
+  it('uses thread-scoped conversation key for Slack group messages', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'golem-thread-group-'));
+    const sessionKeys: string[] = [];
+    const replies: string[] = [];
+
+    const assistant = {
+      async *chat(_text: string, opts: { sessionKey: string }) {
+        sessionKeys.push(opts.sessionKey);
+        yield { type: 'text' as const, content: 'thread reply' };
+        yield { type: 'done' as const, durationMs: 1 };
+      },
+      async setEngine() {},
+      async setModel() {},
+      async getStatus() {
+        return { engine: 'cursor', model: undefined, skills: [] };
+      },
+      async resetSession() {},
+      async listModels() {
+        return [];
+      },
+    };
+
+    const adapter = {
+      async reply(_msg: ChannelMessage, text: string) {
+        replies.push(text);
+      },
+    };
+
+    const msg: ChannelMessage = {
+      channelType: 'slack',
+      senderId: 'U001',
+      senderName: 'Alice',
+      chatId: 'C001',
+      chatType: 'group',
+      text: 'please help',
+      threadId: '1742920000.123456',
+      mentioned: true,
+      raw: {},
+    };
+
+    try {
+      await handleMessage(
+        msg,
+        { name: 'GolemBot', engine: 'cursor' } as any,
+        assistant as any,
+        adapter,
+        'slack',
+        false,
+        dir,
+      );
+
+      expect(sessionKeys).toEqual(['slack:C001:thread:1742920000.123456']);
+      expect(replies).toEqual(['thread reply']);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+      clearGroupChatState('slack:C001:thread:1742920000.123456');
+    }
+  });
+
+  it('uses thread-scoped conversation key for Slack group slash commands', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'golem-thread-cmd-'));
+    const resetKeys: Array<string | undefined> = [];
+    const replies: string[] = [];
+
+    const assistant = {
+      async chat() {
+        throw new Error('chat should not run for slash commands');
+      },
+      async setEngine() {},
+      async setModel() {},
+      async getStatus() {
+        return { engine: 'cursor', model: undefined, skills: [] };
+      },
+      async resetSession(sessionKey?: string) {
+        resetKeys.push(sessionKey);
+      },
+      async listModels() {
+        return [];
+      },
+    };
+
+    const adapter = {
+      async reply(_msg: ChannelMessage, text: string) {
+        replies.push(text);
+      },
+    };
+
+    const msg: ChannelMessage = {
+      channelType: 'slack',
+      senderId: 'U001',
+      senderName: 'Alice',
+      chatId: 'C001',
+      chatType: 'group',
+      text: '/reset',
+      threadId: '1742920000.123456',
+      raw: {},
+    };
+
+    try {
+      await handleMessage(
+        msg,
+        { name: 'GolemBot', engine: 'cursor' } as any,
+        assistant as any,
+        adapter,
+        'slack',
+        false,
+        dir,
+      );
+
+      expect(resetKeys).toEqual(['slack:C001:thread:1742920000.123456']);
+      expect(replies).toEqual(['Session reset.']);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+      clearGroupChatState('slack:C001:thread:1742920000.123456');
+    }
   });
 });
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -27,6 +27,8 @@ export interface ChannelMessage {
   text: string;
   /** Platform-native message ID, used for quote/reply. */
   messageId?: string;
+  /** Platform-native thread or conversation root ID, used for thread-scoped routing. */
+  threadId?: string;
   /** Images attached to the message (downloaded by the adapter). */
   images?: ImageAttachment[];
   /** Files (non-image) attached to the message (downloaded by the adapter). */
@@ -118,7 +120,19 @@ export interface ChannelAdapter {
 }
 
 export function buildSessionKey(msg: ChannelMessage): string {
+  if (msg.channelType === 'slack' && msg.chatType === 'dm' && msg.threadId) {
+    return `slack:${msg.chatId}:${msg.senderId}:thread:${msg.threadId}`;
+  }
   return `${msg.channelType}:${msg.chatId}:${msg.senderId}`;
+}
+
+export function buildConversationKey(
+  msg: Pick<ChannelMessage, 'channelType' | 'chatId' | 'chatType' | 'threadId'>,
+): string {
+  if (msg.channelType === 'slack' && msg.chatType === 'group' && msg.threadId) {
+    return `slack:${msg.chatId}:thread:${msg.threadId}`;
+  }
+  return `${msg.channelType}:${msg.chatId}`;
 }
 
 /**

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -101,6 +101,7 @@ export class SlackAdapter implements ChannelAdapter {
         chatType: 'dm',
         text: message.text || (images.length > 0 ? '(image)' : ''),
         messageId: message.ts,
+        threadId: message.thread_ts || message.ts,
         images: images.length > 0 ? images : undefined,
         raw: message,
       });
@@ -123,6 +124,7 @@ export class SlackAdapter implements ChannelAdapter {
         chatType: 'group',
         text,
         messageId: event.ts,
+        threadId: event.thread_ts || event.ts,
         mentioned: true,
         raw: event,
       });
@@ -173,10 +175,11 @@ export class SlackAdapter implements ChannelAdapter {
         );
       }
     }
+    const threadTs = msg.threadId ?? msg.messageId;
     await this.app.client.chat.postMessage({
       channel: msg.chatId,
       text: mrkdwn,
-      ...(msg.messageId ? { thread_ts: msg.messageId } : {}),
+      ...(threadTs ? { thread_ts: threadTs } : {}),
     });
   }
 
@@ -213,9 +216,10 @@ export class SlackAdapter implements ChannelAdapter {
           senderId: msg.user || 'unknown',
           senderName,
           chatId,
-          chatType: 'group', // determined by caller; conversations.history works for both
+          chatType: chatId.startsWith('D') ? 'dm' : 'group',
           text: msg.text,
           messageId: msg.ts,
+          threadId: msg.thread_ts || msg.ts,
           raw: msg,
         });
       }

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile as readFileAsync } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  buildConversationKey,
   buildSessionKey,
   type ChannelAdapter,
   type ChannelMessage,
@@ -83,7 +84,7 @@ export interface GroupMessage {
   isBot: boolean;
 }
 
-/** Recent message history per group (key: `channelType:chatId`). */
+/** Recent message history per group conversation (channel or Slack thread). */
 export const groupHistories = new Map<string, GroupMessage[]>();
 
 /** Total bot replies sent per group — used as a safety valve against runaway chains. */
@@ -325,7 +326,7 @@ export async function handleMessage(
   // ── Slash command interception ──
   const parsed = parseCommand(userText);
   if (parsed) {
-    const sessionKey = msg.chatType === 'group' ? `${msg.channelType}:${msg.chatId}` : buildSessionKey(msg);
+    const sessionKey = msg.chatType === 'group' ? buildConversationKey(msg) : buildSessionKey(msg);
     const cmdCtx: CommandContext = {
       dir,
       sessionKey,
@@ -353,7 +354,7 @@ export async function handleMessage(
   let injectPass = false;
 
   if (msg.chatType === 'group') {
-    const groupKey = `${msg.channelType}:${msg.chatId}`;
+    const groupKey = buildConversationKey(msg);
     sessionKey = groupKey;
     const gc = resolveGroupChatConfig(config);
 
@@ -608,7 +609,7 @@ export async function handleMessage(
 
     // Update group history with the full reply + increment turn counter
     if (fullReply.trim() && msg.chatType === 'group') {
-      const groupKey = `${msg.channelType}:${msg.chatId}`;
+      const groupKey = buildConversationKey(msg);
       const gc = resolveGroupChatConfig(config);
       const hist = groupHistories.get(groupKey) ?? [];
       hist.push({ senderName: config.name, text: fullReply.trim(), isBot: true });
@@ -712,6 +713,7 @@ export function channelMsgToInbox(
       chatId: msg.chatId,
       chatType: msg.chatType,
       messageId: msg.messageId,
+      threadId: msg.threadId,
       mentioned: msg.mentioned,
     },
   };
@@ -934,7 +936,7 @@ export async function startGateway(opts: GatewayOpts): Promise<void> {
             // Build sessionKey + fullText the same way handleMessage does,
             // but we need the ChannelMessage for reply routing, so we store the
             // raw msg reference keyed by entry ID in a local map.
-            const sessionKey = msg.chatType === 'group' ? `${msg.channelType}:${msg.chatId}` : buildSessionKey(msg);
+            const sessionKey = msg.chatType === 'group' ? buildConversationKey(msg) : buildSessionKey(msg);
 
             const entry = channelMsgToInbox(msg, sessionKey, msg.text);
             log(verbose, `[${type}] enqueued message from ${msg.senderName || msg.senderId}`);
@@ -1028,6 +1030,7 @@ export async function startGateway(opts: GatewayOpts): Promise<void> {
           chatId: chMsg.chatId,
           chatType: chMsg.chatType,
           messageId: chMsg.messageId,
+          threadId: chMsg.threadId,
           text: entry.message,
           raw: {},
           // For history-fetch triage, mentioned is set from the adapter's

--- a/src/history-fetcher.ts
+++ b/src/history-fetcher.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { ChannelAdapter, ChannelMessage } from './channel.js';
+import { buildConversationKey, buildSessionKey, type ChannelAdapter, type ChannelMessage } from './channel.js';
 import { type InboxChannelMsg, type InboxStore } from './inbox.js';
 import type { SeenMessageStore } from './seen-messages.js';
 
@@ -190,7 +190,9 @@ export async function fetchMissedMessages(opts: HistoryFetcherOpts, watermarks: 
 
       log(verbose, `[history-fetch] ${wmKey}: ${newMessages.length} new message(s)`);
 
-      const sessionKey = `${type}:${chat.chatId}`;
+      const conversationMsg = newMessages[newMessages.length - 1];
+      const sessionKey =
+        conversationMsg.chatType === 'group' ? buildConversationKey(conversationMsg) : buildSessionKey(conversationMsg);
 
       // Session-level suppression: if WebSocket delivered any real-time message
       // for this session within the current poll cycle, skip the triage entirely.
@@ -238,7 +240,7 @@ export async function fetchMissedMessages(opts: HistoryFetcherOpts, watermarks: 
 
       // Use the last message's info for reply routing.
       // mentioned is true if ANY message in the batch was @this-bot.
-      const lastMsg = newMessages[newMessages.length - 1];
+      const lastMsg = conversationMsg;
       const anyMentioned = newMessages.some((m) => m.mentioned === true);
       const channelMsg: InboxChannelMsg = {
         channelType: type,
@@ -247,6 +249,7 @@ export async function fetchMissedMessages(opts: HistoryFetcherOpts, watermarks: 
         chatId: chat.chatId,
         chatType: chat.chatType,
         messageId: lastMsg.messageId,
+        threadId: lastMsg.threadId,
         mentioned: anyMentioned || undefined,
       };
 

--- a/src/inbox.ts
+++ b/src/inbox.ts
@@ -13,6 +13,7 @@ export interface InboxChannelMsg {
   chatId: string;
   chatType: 'dm' | 'group';
   messageId?: string;
+  threadId?: string;
   /** Whether the bot was @mentioned in this message. */
   mentioned?: boolean;
 }


### PR DESCRIPTION
## Summary
- isolate Slack DM sessions by thread and add thread-scoped conversation keys for group threads
- route Slack replies, inbox entries, and history-fetch triage through the originating thread so context does not bleed across threads
- add regression coverage for thread-aware session and conversation key handling

## Verification
- pnpm exec vitest run src/__tests__/channel.test.ts src/__tests__/gateway.test.ts
- pnpm build