### PR TITLE
feat: streamline Slack streaming status updates

### DIFF
--- a/src/__tests__/gateway-integration.test.ts
+++ b/src/__tests__/gateway-integration.test.ts
@@ -476,7 +476,11 @@ function makeErrorEventAssistant(): MockAssistant {
 
 type MockAdapter = {
   replies: Array<{ msg: ChannelMessage; text: string; options?: ReplyOptions }>;
+  statusOps: Array<{ type: 'create' | 'update' | 'clear'; id?: string; text?: string }>;
   reply(msg: ChannelMessage, text: string, options?: ReplyOptions): Promise<void>;
+  sendStatus?(msg: ChannelMessage, text: string): Promise<string>;
+  updateStatus?(msg: ChannelMessage, statusId: string, text: string): Promise<void>;
+  clearStatus?(msg: ChannelMessage, statusId: string): Promise<void>;
   maxMessageLength?: number;
   getGroupMembers?: (chatId: string) => Promise<Map<string, string>>;
 };
@@ -484,9 +488,20 @@ type MockAdapter = {
 function makeMockAdapter(maxLen?: number): MockAdapter {
   const obj: MockAdapter = {
     replies: [],
+    statusOps: [],
     maxMessageLength: maxLen,
     async reply(msg: ChannelMessage, text: string, options?: ReplyOptions) {
       obj.replies.push({ msg, text, options });
+    },
+    async sendStatus(_msg: ChannelMessage, text: string) {
+      obj.statusOps.push({ type: 'create', id: 'status-1', text });
+      return 'status-1';
+    },
+    async updateStatus(_msg: ChannelMessage, statusId: string, text: string) {
+      obj.statusOps.push({ type: 'update', id: statusId, text });
+    },
+    async clearStatus(_msg: ChannelMessage, statusId: string) {
+      obj.statusOps.push({ type: 'clear', id: statusId });
     },
   };
   return obj;
@@ -1213,10 +1228,41 @@ describe('handleMessage — full gateway pipeline', () => {
       const msg = makeDmMsg();
       const config = makeConfig({ streaming: { mode: 'streaming', showToolCalls: true } } as any);
       await handleMessage(msg, config, assistant, adapter, 'slack', false, dir);
-      expect(adapter.replies.length).toBe(3);
+      expect(adapter.replies.length).toBe(2);
       expect(adapter.replies[0].text).toBe('Let me check.');
-      expect(adapter.replies[1].text).toBe('🔧 run_tests...');
-      expect(adapter.replies[2].text).toBe('All tests pass.');
+      expect(adapter.replies[1].text).toBe('All tests pass.');
+      expect(adapter.statusOps).toEqual([
+        { type: 'create', id: 'status-1', text: '🔧 run_tests...' },
+        { type: 'update', id: 'status-1', text: '✍️ replying...' },
+        { type: 'update', id: 'status-1', text: '✅ Done' },
+      ]);
+    });
+
+    it('streaming mode includes truncated tool args in tool_call hints', async () => {
+      const assistant = makeStreamingAssistant([
+        {
+          type: 'tool_call',
+          name: 'read',
+          args: '{"filePath":"/Users/makang/.zelda/notes.md","offset":1,"limit":200}',
+        },
+        { type: 'text', content: 'Done reading.' },
+        { type: 'done', sessionId: 'x' },
+      ]);
+      const adapter = makeMockAdapter();
+      const msg = makeDmMsg();
+      const config = makeConfig({ streaming: { mode: 'streaming', showToolCalls: true } } as any);
+      await handleMessage(msg, config, assistant, adapter, 'slack', false, dir);
+      expect(adapter.replies.length).toBe(1);
+      expect(adapter.replies[0].text).toBe('Done reading.');
+      expect(adapter.statusOps).toEqual([
+        {
+          type: 'create',
+          id: 'status-1',
+          text: '🔧 read {"filePath":"/Users/makang/.zelda/notes.md","offset":1,"limit":200}',
+        },
+        { type: 'update', id: 'status-1', text: '✍️ replying...' },
+        { type: 'update', id: 'status-1', text: '✅ Done' },
+      ]);
     });
 
     it('streaming mode does not show tool_call hints when disabled', async () => {
@@ -1297,6 +1343,64 @@ describe('handleMessage — full gateway pipeline', () => {
       await handleMessage(msg, config, assistant, adapter, 'slack', false, dir);
       expect(adapter.replies.length).toBeGreaterThanOrEqual(1);
       expect(adapter.replies.some((r) => r.text.includes('error occurred'))).toBe(true);
+    });
+
+    it('sends a thinking status before a delayed first reply', async () => {
+      vi.useFakeTimers();
+      try {
+        const assistant: MockAssistant = {
+          ...mockAssistantStubs,
+          callCount: 0,
+          lastSessionKey: undefined,
+          lastPrompt: undefined,
+          async *chat(message: string, opts: { sessionKey?: string } = {}) {
+            assistant.callCount++;
+            assistant.lastPrompt = message;
+            assistant.lastSessionKey = opts.sessionKey;
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+            yield { type: 'text' as const, content: 'Final answer.' };
+            yield { type: 'done' as const, sessionId: 'x' };
+          },
+        };
+        const adapter = makeMockAdapter();
+        const msg = makeDmMsg();
+        const promise = handleMessage(msg, makeConfig(), assistant, adapter, 'slack', false, dir);
+
+        await vi.advanceTimersByTimeAsync(1600);
+        expect(adapter.statusOps[0]).toEqual({ type: 'create', id: 'status-1', text: '⏳ thinking...' });
+
+        await vi.advanceTimersByTimeAsync(1000);
+        await promise;
+
+        expect(adapter.replies[0].text).toBe('Final answer.');
+        expect(adapter.statusOps[1]).toEqual({ type: 'update', id: 'status-1', text: '✍️ replying...' });
+        expect(adapter.statusOps[2]).toEqual({ type: 'update', id: 'status-1', text: '✅ Done' });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('updates a single status message across multiple tool calls', async () => {
+      const assistant = makeStreamingAssistant([
+        { type: 'tool_call', name: 'read', args: '{"filePath":"/tmp/a.txt"}' },
+        { type: 'tool_call', name: 'bash', args: '{"command":"pnpm vitest run src/__tests__/gateway.test.ts"}' },
+        { type: 'text', content: 'Done.' },
+        { type: 'done', sessionId: 'x' },
+      ]);
+      const adapter = makeMockAdapter();
+      const msg = makeDmMsg();
+      const config = makeConfig({ streaming: { mode: 'streaming', showToolCalls: true } } as any);
+
+      await handleMessage(msg, config, assistant, adapter, 'slack', false, dir);
+
+      expect(adapter.replies).toHaveLength(1);
+      expect(adapter.replies[0].text).toBe('Done.');
+      expect(adapter.statusOps).toEqual([
+        { type: 'create', id: 'status-1', text: '🔧 read {"filePath":"/tmp/a.txt"}' },
+        { type: 'update', id: 'status-1', text: '🔧 bash {"command":"pnpm vitest run src/__tests__/gateway.test.ts"}' },
+        { type: 'update', id: 'status-1', text: '✍️ replying...' },
+        { type: 'update', id: 'status-1', text: '✅ Done' },
+      ]);
     });
   });
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -94,6 +94,15 @@ export interface ChannelAdapter {
    */
   typing?(msg: ChannelMessage): Promise<void>;
   /**
+   * Optional: create a temporary status/progress message that can be updated.
+   * Returns a platform-native status identifier if supported.
+   */
+  sendStatus?(msg: ChannelMessage, text: string): Promise<string>;
+  /** Optional: update a previously created status/progress message. */
+  updateStatus?(msg: ChannelMessage, statusId: string, text: string): Promise<void>;
+  /** Optional: clear a previously created status/progress message. */
+  clearStatus?(msg: ChannelMessage, statusId: string): Promise<void>;
+  /**
    * Optional: resolve group members for @mention support.
    * Returns a map of display name → platform-specific user ID.
    * Called by the gateway when the AI reply contains @mentions.

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -85,7 +85,9 @@ export class SlackAdapter implements ChannelAdapter {
     this.app.message(async ({ message }: any) => {
       if (message.subtype) return; // ignore edits, bot messages, etc.
       if (message.channel_type !== 'im') return; // group messages handled via app_mention
-      if (this.dedup(message.client_msg_id || message.ts)) return;
+      const dedupId = message.client_msg_id || message.ts;
+      const isDuplicate = this.dedup(dedupId);
+      if (isDuplicate) return;
 
       // Download attached images (Slack file uploads)
       const images = await this.downloadFiles(message.files);
@@ -180,6 +182,33 @@ export class SlackAdapter implements ChannelAdapter {
       channel: msg.chatId,
       text: mrkdwn,
       ...(threadTs ? { thread_ts: threadTs } : {}),
+    });
+  }
+
+  async sendStatus(msg: ChannelMessage, text: string): Promise<string> {
+    if (!this.app) return '';
+    const res = await this.app.client.chat.postMessage({
+      channel: msg.chatId,
+      text: markdownToMrkdwn(text),
+      ...((msg.threadId ?? msg.messageId) ? { thread_ts: msg.threadId ?? msg.messageId } : {}),
+    });
+    return res.ts || '';
+  }
+
+  async updateStatus(msg: ChannelMessage, statusId: string, text: string): Promise<void> {
+    if (!this.app || !statusId) return;
+    await this.app.client.chat.update({
+      channel: msg.chatId,
+      ts: statusId,
+      text: markdownToMrkdwn(text),
+    });
+  }
+
+  async clearStatus(msg: ChannelMessage, statusId: string): Promise<void> {
+    if (!this.app || !statusId) return;
+    await this.app.client.chat.delete({
+      channel: msg.chatId,
+      ts: statusId,
     });
   }
 

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -64,6 +64,15 @@ export function splitMessage(text: string, maxLen: number): string[] {
   return chunks;
 }
 
+function summarizeToolCall(name: string, args: string, maxLen = 72): string {
+  const firstToken = name.split(/\s/)[0];
+  const label = firstToken.includes('/') ? firstToken.split('/').pop()! : firstToken;
+  const compactArgs = args.replace(/\s+/g, ' ').trim();
+  if (!compactArgs || compactArgs === '{}' || compactArgs === '[]') return `🔧 ${label}...`;
+  const preview = compactArgs.length > maxLen ? `${compactArgs.slice(0, maxLen)}...` : compactArgs;
+  return `🔧 ${label} ${preview}`;
+}
+
 interface GatewayOpts {
   dir?: string;
   port?: number;
@@ -317,7 +326,10 @@ export async function handleMessage(
   msg: ChannelMessage,
   config: GolemConfig,
   assistant: Pick<Assistant, 'chat' | 'setEngine' | 'setModel' | 'getStatus' | 'resetSession' | 'listModels'>,
-  adapter: Pick<ChannelAdapter, 'reply' | 'maxMessageLength' | 'typing' | 'getGroupMembers'>,
+  adapter: Pick<
+    ChannelAdapter,
+    'reply' | 'maxMessageLength' | 'typing' | 'getGroupMembers' | 'sendStatus' | 'updateStatus' | 'clearStatus'
+  >,
   channelType: string,
   verbose: boolean,
   dir: string,
@@ -423,7 +435,6 @@ export async function handleMessage(
   }
 
   log(verbose, `[${channelType}] received from ${senderLabel}: "${userText}" → session ${sessionKey}`);
-
   // Send typing indicator immediately, then refresh every 4s while waiting for AI.
   // Telegram's typing action expires after ~5s, so we keep it alive.
   let typingTimer: ReturnType<typeof setInterval> | undefined;
@@ -452,10 +463,67 @@ export async function handleMessage(
 
   const maxLen = adapter.maxMessageLength ?? 4000;
   const streamingConfig = resolveStreamingConfig(config);
+  let hasVisibleStatus = false;
+  let thinkingStatusTimer: ReturnType<typeof setTimeout> | undefined;
+  let statusMessageId: string | undefined;
+  let statusMessageText: string | undefined;
+  let statusFinalized = false;
+
+  const cancelThinkingStatus = () => {
+    if (thinkingStatusTimer !== undefined) {
+      clearTimeout(thinkingStatusTimer);
+      thinkingStatusTimer = undefined;
+    }
+  };
+
+  const sendStatusUpdate = async (text: string): Promise<void> => {
+    if (!text.trim()) return;
+    cancelThinkingStatus();
+    if (adapter.sendStatus && adapter.updateStatus && adapter.clearStatus) {
+      if (!statusMessageId) {
+        statusMessageId = await adapter.sendStatus(msg, text.trim());
+      } else {
+        await adapter.updateStatus(msg, statusMessageId, text.trim());
+      }
+      statusMessageText = text.trim();
+      return;
+    }
+    if (hasVisibleStatus) return;
+    hasVisibleStatus = true;
+    await adapter.reply(msg, text.trim());
+  };
+
+  const finalizeStatusUpdate = async (finalText = '✅ Done'): Promise<void> => {
+    cancelThinkingStatus();
+    if (!statusMessageId) return;
+    if (adapter.updateStatus) {
+      await adapter.updateStatus(msg, statusMessageId, finalText);
+      statusMessageText = finalText;
+      statusFinalized = true;
+      return;
+    }
+    if (adapter.clearStatus) {
+      const currentStatusId = statusMessageId;
+      statusMessageId = undefined;
+      await adapter.clearStatus(msg, currentStatusId);
+    }
+  };
+
+  if (msg.chatType === 'dm') {
+    thinkingStatusTimer = setTimeout(() => {
+      sendStatusUpdate('⏳ thinking...').catch(() => {});
+    }, 1500);
+  }
 
   // Helper: send a text chunk to the IM channel (handles splitMessage + mentions).
   const sendChunk = async (text: string): Promise<void> => {
     if (!text.trim()) return;
+    hasVisibleStatus = true;
+    cancelThinkingStatus();
+    if (statusMessageId && adapter.updateStatus && statusMessageText !== '✍️ replying...') {
+      await adapter.updateStatus(msg, statusMessageId, '✍️ replying...');
+      statusMessageText = '✍️ replying...';
+    }
     // Final safety net: never send [PASS]/[SKIP] sentinel values to IM
     const sentinel = text.trim();
     if (sentinel === '[PASS]' || sentinel === '[SKIP]') {
@@ -486,7 +554,6 @@ export async function handleMessage(
   try {
     let fullReply = '';
     let hasError = false;
-
     // When injectPass is active (smart mode, not mentioned), force buffered behavior
     // to prevent [PASS] sentinel from leaking to IM before we can detect and suppress it.
     const effectiveMode = injectPass ? 'buffered' : streamingConfig.mode;
@@ -532,15 +599,9 @@ export async function handleMessage(
           // Agent switches to tool use — flush accumulated text first
           await flush('tool_call');
           if (streamingConfig.showToolCalls) {
-            // Extract a short tool label from the tool name.
-            // Codex: "/bin/bash -lc 'cd ... && ls -la'" → "bash"
-            // Claude Code: "Bash", "Read" → as-is
-            // OpenCode: "bash", "read" → as-is
-            const rawName = event.name;
-            const firstToken = rawName.split(/\s/)[0]; // "/bin/bash" or "Bash" or "read"
-            const label = firstToken.includes('/') ? firstToken.split('/').pop()! : firstToken;
-            log(verbose, `[${channelType}] stream tool_call: ${label}`);
-            await adapter.reply(msg, `🔧 ${label}...`);
+            const hint = summarizeToolCall(event.name, event.args);
+            log(verbose, `[${channelType}] stream tool_call: ${hint}`);
+            await sendStatusUpdate(hint);
           } else {
             log(verbose, `[${channelType}] stream tool_call: ${event.name.slice(0, 40)}`);
           }
@@ -575,6 +636,7 @@ export async function handleMessage(
       }
 
       if (fullReply.trim()) {
+        await finalizeStatusUpdate();
         log(verbose, `[${channelType}] replied to ${senderLabel}: "${fullReply.trim().slice(0, 80)}..." (streaming)`);
         trackMetrics({ responsePreview: fullReply.trim().slice(0, 120) });
       }
@@ -608,6 +670,7 @@ export async function handleMessage(
 
       if (fullReply.trim()) {
         await sendChunk(fullReply);
+        await finalizeStatusUpdate();
         log(verbose, `[${channelType}] replied to ${senderLabel}: "${fullReply.trim().slice(0, 80)}..."`);
         trackMetrics({ responsePreview: fullReply.trim().slice(0, 120) });
       }
@@ -631,6 +694,10 @@ export async function handleMessage(
       // best effort
     }
   } finally {
+    if (!statusFinalized && statusMessageId) {
+      await finalizeStatusUpdate();
+    }
+    cancelThinkingStatus();
     if (typingTimer !== undefined) clearInterval(typingTimer);
   }
 }
@@ -1047,10 +1114,16 @@ export async function startGateway(opts: GatewayOpts): Promise<void> {
         // For inbox entries (especially history-fetch), the raw object is empty,
         // so adapter.reply() may fail (e.g. Discord needs raw.reply()).
         // Wrap adapter to fallback to send() when reply() throws.
-        const wrappedAdapter: Pick<ChannelAdapter, 'reply' | 'maxMessageLength' | 'typing' | 'getGroupMembers'> = {
+        const wrappedAdapter: Pick<
+          ChannelAdapter,
+          'reply' | 'maxMessageLength' | 'typing' | 'getGroupMembers' | 'sendStatus' | 'updateStatus' | 'clearStatus'
+        > = {
           maxMessageLength: adapter.maxMessageLength,
           typing: adapter.typing?.bind(adapter),
           getGroupMembers: adapter.getGroupMembers?.bind(adapter),
+          sendStatus: adapter.sendStatus?.bind(adapter),
+          updateStatus: adapter.updateStatus?.bind(adapter),
+          clearStatus: adapter.clearStatus?.bind(adapter),
           reply: async (m, text, opts) => {
             try {
               await adapter.reply(m, text, opts);


### PR DESCRIPTION
## Summary
- replace separate Slack thinking and tool-call messages with a single updatable status message
- show clearer status transitions for long-running turns: thinking, tool activity, replying, and done
- keep tool-call details concise by updating the shared status message instead of posting a new message per tool event