### PR TITLE
feat(wecom): streaming status pipeline, send-media protocol, and slash command streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ dist/
 .env.local
 docs/.vitepress/cache/
 docs/drafts/
+# Agent-generated temp files for the send-media protocol (runtime dir, auto-created by gateway)
+temp_file/
 # GolemBot runtime files (local bot instance, not part of the library)
 golem.yaml
 skills/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,13 @@
 # Assistant Context
 
 ## Installed Skills
-- general: General-purpose personal AI assistant — everyday conversation, information management, file operations, persistent memory
-- im-adapter: IM channel response guidelines — adapted for instant messaging platforms like Lark, DingTalk, WeCom, etc.
+- escalation: Escalate unresolvable or sensitive requests to a human agent by recording an escalation entry. Use when the user asks to speak to a human, the bot cannot answer confidently, the request involves financial, legal, or security concerns, a safety issue is detected, or the user is frustrated after repeated failures.
+- general: Handle everyday conversation, answer questions, manage files, take notes, run scripts, and maintain persistent memory across sessions. Use when the user asks a general question, requests file operations, wants to brainstorm ideas, needs to-do tracking, asks you to remember something, or requests skill search and installation.
+- im-adapter: Format responses for instant messaging platforms such as Lark, DingTalk, WeCom, Slack, and Telegram. Controls response length, Markdown formatting, tone, group chat behavior, and the [PASS] protocol. Also covers sending images and files to the chat via [SEND_IMAGE]/[SEND_FILE] markers when the user asks for a picture or file. Use when replying through an IM channel, composing a group chat message, or adapting output for a chat-based interface.
+- kb-guide: Search, read, create, and update knowledge base entries via MCP-connected KB tools. Use when the user asks to look up documentation, find existing articles, check if docs exist on a topic, create a new KB entry, update an existing document, or when domain questions should be answered from the knowledge base first.
+- message-push: Send proactive messages to IM groups or individual users via the gateway Send API. Use when the user says to send, post, notify, forward, or tell someone a message on Feishu, Slack, Telegram, Discord, DingTalk, or WeCom.
+- multi-bot: Coordinates responses between multiple GolemBot instances in a shared fleet. Use when the bot operates in a group chat with other bots, needs to decide whether to respond or pass, or must call a peer bot's API to fetch cross-domain data.
+- task-manager: Creates and manages scheduled tasks, cron jobs, recurring reminders, and timers via the Task HTTP API. Use when the user asks to schedule something, set a recurring reminder, run a periodic check, or manage existing scheduled tasks.
 
 ## Directory Structure
 - skills/ — Skills directory (each subdirectory is a skill, containing SKILL.md and optional scripts)

--- a/docs/channels/wecom.md
+++ b/docs/channels/wecom.md
@@ -37,6 +37,7 @@ WECOM_SECRET=xxxxxxxxxxxxxxxxxx
 - **Connection**: The SDK establishes and maintains a WebSocket connection to WeCom servers
 - **Reconnection**: Automatic reconnection and heartbeat are handled by the SDK
 - **Messages**: Incoming messages are received via WebSocket events and emitted as `ChannelMessage` (text only)
+- **Sending media**: The bot can send images and files when the agent outputs a `[SEND_IMAGE: <path>]` or `[SEND_FILE: <path>]` marker line. Images and files are delivered as separate media messages — the bot sends media messages first, then the completion marker ("mission complete") after a short confirmation delay, so media appears before the marker in the WeCom UI. Agents should save files to the `temp_file/` workspace directory (auto-created at gateway startup). Minimum file size is 5 bytes. Images must be PNG, JPG, or GIF and ≤10MB; files ≤20MB. Paths can be relative to the assistant workspace or absolute paths inside it; paths outside the workspace are rejected.
 - **Reply**: Sends messages via the SDK's built-in reply method
 - **Proactive messaging**: `send()` is supported — the adapter can proactively send messages to any chat
 - **Chat type**: Always `dm` (WeCom bot messages are direct messages)
@@ -54,4 +55,4 @@ The adapter connects to WeCom via WebSocket automatically. No port forwarding or
 - Like Feishu and DingTalk, WeCom now uses **WebSocket** — no public IP or reverse proxy required
 - The `@wecom/aibot-node-sdk` handles reconnection and heartbeat automatically
 - The max message length is 2,048 characters; longer responses are automatically split
-- Only text messages are processed
+- Only text messages are received; the bot can send images (PNG, JPG, GIF; ≤10MB) and files (≤20MB, min 5 bytes) as separate media messages via `[SEND_IMAGE: <path>]` / `[SEND_FILE: <path>]` markers, delivered right before the completion marker. Agents save to `temp_file/` (workspace-relative) by default; paths outside the workspace are rejected.

--- a/docs/zh/channels/wecom.md
+++ b/docs/zh/channels/wecom.md
@@ -37,6 +37,7 @@ WECOM_SECRET=xxxxxxxxxxxxxxxxxx
 - **连接**：SDK 自动建立并维护与企业微信服务器的 WebSocket 连接
 - **重连**：SDK 自动处理重连和心跳
 - **消息**：通过 WebSocket 事件接收入站消息，转换为 `ChannelMessage`（仅文本）
+- **发送媒体**：Bot 可通过 agent 输出的 `[SEND_IMAGE: <path>]` 或 `[SEND_FILE: <path>]` 标记行发送图片和文件。图片和文件作为独立媒体消息发送——bot 先发送媒体消息，经过短暂确认延迟后再发送完成标记（"mission complete"），从而媒体在标记之前显示于 WeCom UI 中。Agent 默认将文件保存到 `temp_file/` 工作区目录（网关启动时自动创建）。最小文件大小为 5 字节。图片需为 PNG、JPG 或 GIF 格式，≤10MB；文件 ≤20MB。路径可相对于助手工作区，或为工作区内的绝对路径；工作区外的路径将被拒绝。
 - **回复**：通过 SDK 内置的回复方法发送消息
 - **主动消息**：支持 `send()` —— 适配器可以主动向任意会话发送消息
 - **会话类型**：始终为 `dm`（企业微信 Bot 消息为私聊）
@@ -54,4 +55,4 @@ golembot gateway --verbose
 - 与飞书和钉钉一样，企业微信现在也使用 **WebSocket** —— 无需公网 IP 或反向代理
 - `@wecom/aibot-node-sdk` 自动处理重连和心跳
 - 最大消息长度 2,048 字符；更长的回复会自动拆分
-- 仅处理文本消息
+- 仅接收文本消息；Bot 可通过 `[SEND_IMAGE: <path>]` / `[SEND_FILE: <path>]` 标记发送图片（PNG、JPG、GIF；≤10MB）和文件（≤20MB，最小 5 字节），作为独立媒体消息在完成标记前发送。Agent 默认保存到 `temp_file/`（工作区相对路径）；工作区外的路径将被拒绝。

--- a/skills/im-adapter/SKILL.md
+++ b/skills/im-adapter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: im-adapter
-description: "Format responses for instant messaging platforms such as Lark, DingTalk, WeCom, Slack, and Telegram. Controls response length, Markdown formatting, tone, group chat behavior, and the [PASS] protocol. Also covers sending images and files to the chat via [SEND_IMAGE]/[SEND_FILE] markers when the user asks for a picture or file. Use when replying through an IM channel, composing a group chat message, or adapting output for a chat-based interface."
+description: "Format responses for instant messaging platforms such as Lark, DingTalk, WeCom, Slack, and Telegram. Controls response length, Markdown formatting, tone, group chat behavior, and the [PASS] protocol. Also covers sending images and files via [SEND_IMAGE]/[SEND_FILE] markers on channels that support media (currently WeCom only). Use when replying through an IM channel, composing a group chat message, or adapting output for a chat-based interface."
 ---
 
 # IM Channel Response Guidelines
@@ -67,6 +67,8 @@ Group messages are prefixed with metadata like `[Group: slack-team | MemoryFile:
 - Summarize the result in one sentence, attaching any necessary data or filenames
 
 ## Sending Images and Files
+
+**Channel support:** The [SEND_IMAGE]/[SEND_FILE] marker protocol works only on channels whose adapter implements `sendMedia` — currently only **WeCom**. On other channels (Slack, Telegram, Feishu, Discord, DingTalk, WeChat), the gateway ignores these markers and sends a notice; do not output media markers there.
 
 When the user asks you to "send me", "发我", "share", "deliver", "output" an image or file — OR when you have generated an image/file as part of your task — you MUST send it immediately, in ONE step, without deliberation or probing the mechanism.
 

--- a/skills/im-adapter/SKILL.md
+++ b/skills/im-adapter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: im-adapter
-description: "Format responses for instant messaging platforms such as Lark, DingTalk, WeCom, Slack, and Telegram. Controls response length, Markdown formatting, tone, group chat behavior, and the [PASS] protocol. Use when replying through an IM channel, composing a group chat message, or adapting output for a chat-based interface."
+description: "Format responses for instant messaging platforms such as Lark, DingTalk, WeCom, Slack, and Telegram. Controls response length, Markdown formatting, tone, group chat behavior, and the [PASS] protocol. Also covers sending images and files to the chat via [SEND_IMAGE]/[SEND_FILE] markers when the user asks for a picture or file. Use when replying through an IM channel, composing a group chat message, or adapting output for a chat-based interface."
 ---
 
 # IM Channel Response Guidelines
@@ -65,6 +65,33 @@ Group messages are prefixed with metadata like `[Group: slack-team | MemoryFile:
 - If the user asks you to perform an action (query data, write a file, etc.), briefly confirm first, then report the result when done
 - No need to provide detailed progress updates during the process, unless it takes a long time and the user should be informed
 - Summarize the result in one sentence, attaching any necessary data or filenames
+
+## Sending Images and Files
+
+When the user asks you to "send me", "发我", "share", "deliver", "output" an image or file — OR when you have generated an image/file as part of your task — you MUST send it immediately, in ONE step, without deliberation or probing the mechanism.
+
+**How to send (the ONLY steps):**
+1. Save the file into the `temp_file/` directory inside the workspace. Create `temp_file/` if it does not exist.
+2. Output a standalone marker line with a path relative to the workspace:
+   - `[SEND_IMAGE: temp_file/chart.png]` — for images (PNG, JPG, GIF; ≤10MB)
+   - `[SEND_FILE: temp_file/report.pdf]` — for files (≤20MB)
+3. Narrate briefly in normal text what you are sending.
+
+**Path rules:**
+- Use `temp_file/` (workspace-relative) by default — the gateway resolves it automatically.
+- Absolute paths work for files inside the workspace (e.g. an absolute path to `temp_file/`). Paths outside the workspace are rejected.
+- Minimum file size: 5 bytes.
+
+**The marker line is consumed by the system and not shown to the user.** Do not explain the mechanism or ask permission — just generate and send.
+
+Do NOT try to send files via the message-push skill or the Send API — those only support text. Use the markers above.
+
+Example:
+```
+我已经生成了销售数据图表。
+[SEND_IMAGE: temp_file/sales-chart.png]
+需要原始数据的话告诉我，我可以把 CSV 也发给你。
+```
 
 ## Things to Avoid
 

--- a/skills/message-push/SKILL.md
+++ b/skills/message-push/SKILL.md
@@ -9,6 +9,8 @@ You can send messages to IM channels proactively -- to groups or individual user
 
 ## Recognizing Push Intent
 
+Note: if the user asks you to send a FILE or IMAGE (e.g. a generated document, chart, photo), do NOT use this skill — instead save to `temp_file/` and emit `[SEND_IMAGE: ...]` / `[SEND_FILE: ...]` markers (see the im-adapter skill). This skill only sends TEXT messages.
+
 Watch for phrases like:
 - "send this to the ops group"
 - "tell Alice in DM that..."

--- a/src/__tests__/engine-abort.test.ts
+++ b/src/__tests__/engine-abort.test.ts
@@ -94,7 +94,12 @@ describe('engine abort handling', () => {
       vi.doMock('node:child_process', () => ({ spawn: vi.fn(() => new FakeChild()) }));
       vi.doMock('../engines/shared.js', async (importOriginal) => {
         const original = await importOriginal<typeof import('../engines/shared.js')>();
-        return { ...original, isOnPath: () => true, spawnCommand: vi.fn(() => new FakeChild()) };
+        return {
+          ...original,
+          isOnPath: () => true,
+          resolveOnPath: () => 'opencode',
+          spawnCommand: vi.fn(() => new FakeChild()),
+        };
       });
       const { OpenCodeEngine } = await import('../engines/opencode.js');
       const message = await collectAbortMessage(new OpenCodeEngine(), workspace);

--- a/src/__tests__/gateway-integration.test.ts
+++ b/src/__tests__/gateway-integration.test.ts
@@ -952,7 +952,8 @@ describe('handleMessage — full gateway pipeline', () => {
       const msg = makeDmMsg();
       await handleMessage(msg, makeConfig(), assistant, adapter, 'slack', false, dir);
       expect(adapter.replies).toHaveLength(1);
-      expect(adapter.replies[0].text).toContain('error occurred');
+      // Generic engine errors surface the agent's actual error output.
+      expect(adapter.replies[0].text).toContain('engine blew up');
     });
 
     it('exception in assistant.chat → sends fallback error reply', async () => {
@@ -1375,7 +1376,8 @@ describe('handleMessage — full gateway pipeline', () => {
       const config = makeConfig({ streaming: { mode: 'streaming' } } as any);
       await handleMessage(msg, config, assistant, adapter, 'slack', false, dir);
       expect(adapter.replies.length).toBeGreaterThanOrEqual(1);
-      expect(adapter.replies.some((r) => r.text.includes('error occurred'))).toBe(true);
+      // Generic engine errors surface the agent's actual error output.
+      expect(adapter.replies.some((r) => r.text.includes('engine crashed'))).toBe(true);
     });
 
     it('streaming mode sends an interruption notice after a partial timeout', async () => {
@@ -2113,6 +2115,51 @@ describe('auto-continue relay ([CONTINUE] sentinel)', () => {
       const adapter = makeMockAdapter();
       await handleMessage(makeDmMsg(), makeConfig(), obj, adapter, 'slack', false, dir);
       expect(obj.callCount).toBe(1);
+    });
+
+    it('closes leftover typing streams for nativeStreaming adapters at task end', async () => {
+      // Regression: a /stop landing between 4s typing ticks leaves an open
+      // loading stream open (WeCom). The finally block must issue a silent
+      // clearStatus(msg, '', '') to close it.
+      const clearCalls: Array<{ statusId: string; finalText: string }> = [];
+      const adapter = makeMockAdapter() as MockAdapter & {
+        nativeStreaming: boolean;
+        typing: (m: ChannelMessage) => Promise<void>;
+        clearStatus: (m: ChannelMessage, statusId: string, finalText?: string) => Promise<void>;
+      };
+      adapter.nativeStreaming = true;
+      adapter.typing = vi.fn(async () => {});
+      adapter.clearStatus = vi.fn(async (_m, statusId, finalText = '') => {
+        clearCalls.push({ statusId, finalText });
+      });
+
+      const obj: MockAssistant = {
+        ...mockAssistantStubs,
+        callCount: 0,
+        lastSessionKey: undefined,
+        lastPrompt: undefined,
+        async *chat(message: string, opts: { sessionKey?: string } = {}) {
+          const round = obj.callCount++;
+          obj.lastPrompt = message;
+          obj.lastSessionKey = opts.sessionKey;
+          if (round === 0) {
+            // Round 1 signals CONTINUE → relay sets the 4s typing interval.
+            yield { type: 'text' as const, content: 'step 1\n[CONTINUE]' };
+            yield { type: 'done' as const, sessionId: 'mock-sid' };
+          } else {
+            // Round 2 (relay) aborts (simulates /stop) → relay breaks → finally runs.
+            yield { type: 'error' as const, message: 'Agent invocation stopped by user' };
+          }
+        },
+      };
+
+      await handleMessage(makeDmMsg(), makeConfig(), obj, adapter, 'slack', false, dir);
+
+      // The relay must have happened (two chat rounds) and started the typing interval.
+      expect(obj.callCount).toBe(2);
+      expect(adapter.typing).toHaveBeenCalled();
+      // The finally block must have issued a silent cleanup call (empty finalText).
+      expect(clearCalls.some((c) => c.finalText === '')).toBe(true);
     });
 
     it('is interrupted when a newer message arrives for the same session', async () => {

--- a/src/__tests__/gateway-integration.test.ts
+++ b/src/__tests__/gateway-integration.test.ts
@@ -1685,6 +1685,34 @@ describe('handleMessage — full gateway pipeline', () => {
       await handleMessage(msg, makeConfig(), assistant, adapter, 'slack', false, dir);
       expect(adapter.replies[0].text).toContain('/cron');
     });
+
+    // PR #49 blocker 1 regression: Telegram implements typing + a two-param
+    // clearStatus(msg, statusId) but no nativeStreaming, so gateway.ts:546
+    // routes slash-command output through the clearStatus branch. Telegram's
+    // clearStatus (src/channels/telegram.ts:160) returns early on an empty
+    // statusId and never receives finalText, so the slash output is silently
+    // dropped unless it is delivered via the reply() path instead.
+    it('slash command output is delivered via reply for non-nativeStreaming adapters (Telegram)', async () => {
+      const assistant = makeMockAssistant('should not be called');
+      // Telegram-shaped adapter: typing + two-param clearStatus, no nativeStreaming.
+      const adapter: MockAdapter & { typing?: (msg: ChannelMessage) => Promise<void> } = {
+        replies: [],
+        statusOps: [],
+        async reply(msg: ChannelMessage, text: string, options?: ReplyOptions) {
+          adapter.replies.push({ msg, text, options });
+        },
+        async typing() {},
+        async clearStatus(msg: ChannelMessage, statusId: string) {
+          if (!statusId) return; // Telegram: empty statusId → no-op, finalText ignored.
+          adapter.statusOps.push({ type: 'clear', id: statusId });
+        },
+      };
+      const msg = makeDmMsg({ text: '/help' });
+      await handleMessage(msg, makeConfig(), assistant, adapter, 'slack', false, dir);
+      expect(assistant.callCount).toBe(0);
+      expect(adapter.replies.length).toBe(1);
+      expect(adapter.replies[0].text).toContain('/help');
+    });
   });
 
   // ── /cron E2E through gateway handleMessage ──────────────────────────────

--- a/src/__tests__/gateway-media.test.ts
+++ b/src/__tests__/gateway-media.test.ts
@@ -1,0 +1,791 @@
+import { mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ChannelMessage } from '../channel.js';
+import type { StreamEvent } from '../engine.js';
+import type { GroupMessage } from '../gateway.js';
+import type { GolemConfig } from '../workspace.js';
+
+// 鈹€鈹€ extractMediaMarkers (pure helper) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
+
+describe('extractMediaMarkers', () => {
+  let extractMediaMarkers: typeof import('../gateway.js').extractMediaMarkers;
+
+  beforeEach(async () => {
+    const mod = await import('../gateway.js');
+    extractMediaMarkers = mod.extractMediaMarkers;
+  });
+
+  it('returns original text unchanged when no markers are present', () => {
+    const result = extractMediaMarkers('hello world\nhow are you?');
+    expect(result.body).toBe('hello world\nhow are you?');
+    expect(result.markers).toEqual([]);
+  });
+
+  it('extracts and strips a single SEND_IMAGE marker', () => {
+    const result = extractMediaMarkers('[SEND_IMAGE: /tmp/photo.png]');
+    expect(result.body).toBe('');
+    expect(result.markers).toEqual([{ kind: 'image', path: '/tmp/photo.png' }]);
+  });
+
+  it('extracts and strips a single SEND_FILE marker', () => {
+    const result = extractMediaMarkers('[SEND_FILE: /tmp/report.pdf]');
+    expect(result.body).toBe('');
+    expect(result.markers).toEqual([{ kind: 'file', path: '/tmp/report.pdf' }]);
+  });
+
+  it('strips markers but preserves surrounding text', () => {
+    const result = extractMediaMarkers('before text\n[SEND_IMAGE: img.png]\nafter text');
+    expect(result.markers).toEqual([{ kind: 'image', path: 'img.png' }]);
+    expect(result.body).toMatch(/before text/);
+    expect(result.body).toMatch(/after text/);
+    expect(result.body).not.toContain('[SEND_IMAGE:');
+  });
+
+  it('handles multiple markers in one reply', () => {
+    const result = extractMediaMarkers(
+      'start\n[SEND_IMAGE: a.png]\nmiddle\n[SEND_FILE: b.pdf]\n[SEND_IMAGE: c.jpg]\nend',
+    );
+    expect(result.markers).toEqual([
+      { kind: 'image', path: 'a.png' },
+      { kind: 'file', path: 'b.pdf' },
+      { kind: 'image', path: 'c.jpg' },
+    ]);
+    expect(result.body).not.toContain('[SEND_IMAGE:');
+    expect(result.body).not.toContain('[SEND_FILE:');
+    expect(result.body).toMatch(/start/);
+    expect(result.body).toMatch(/middle/);
+    expect(result.body).toMatch(/end/);
+  });
+
+  it('trims whitespace around paths', () => {
+    const result = extractMediaMarkers('[SEND_IMAGE:   /tmp/foo.png  ]');
+    expect(result.markers).toEqual([{ kind: 'image', path: '/tmp/foo.png' }]);
+  });
+
+  it('normalises IMAGE/FILE case to lowercase in kind (case-insensitive match)', () => {
+    const r1 = extractMediaMarkers('[SEND_image: x.png]');
+    const r2 = extractMediaMarkers('[SEND_File: y.pdf]');
+    expect(r1.markers).toHaveLength(1);
+    expect(r1.markers[0].kind).toBe('image');
+    expect(r2.markers).toHaveLength(1);
+    expect(r2.markers[0].kind).toBe('file');
+  });
+
+  it('does NOT match markers that are not on standalone lines', () => {
+    const text = 'I will send [SEND_IMAGE: x.png] inline here.';
+    const result = extractMediaMarkers(text);
+    expect(result.markers).toEqual([]);
+    expect(result.body).toBe(text);
+  });
+
+  it('does NOT match malformed markers with missing path', () => {
+    const text = '[SEND_IMAGE:]\n[SEND_FILE]\n[SEND_IMAGE]';
+    const result = extractMediaMarkers(text);
+    expect(result.markers).toEqual([]);
+    expect(result.body).toBe(text);
+  });
+
+  it('returns empty body and empty markers for empty input', () => {
+    const result = extractMediaMarkers('');
+    expect(result.body).toBe('');
+    expect(result.markers).toEqual([]);
+  });
+
+  it('does NOT match marker with trailing content on same line', () => {
+    const result = extractMediaMarkers('some [SEND_IMAGE: x.png] trailing text');
+    expect(result.markers).toEqual([]);
+  });
+
+  it('is idempotent - second call on stripped body yields no markers', () => {
+    const first = extractMediaMarkers('hello\n[SEND_IMAGE: x.png]\nworld');
+    expect(first.markers).toHaveLength(1);
+    const second = extractMediaMarkers(first.body);
+    expect(second.markers).toEqual([]);
+    expect(second.body).toBe(first.body);
+  });
+});
+
+// 鈹€鈹€ resolveOutboundPath (path security helper) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
+
+describe('resolveOutboundPath', () => {
+  let resolveOutboundPath: typeof import('../gateway.js').resolveOutboundPath;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'golem-rp-'));
+    const mod = await import('../gateway.js');
+    resolveOutboundPath = mod.resolveOutboundPath;
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('resolves a relative path inside the base directory', async () => {
+    const result = await resolveOutboundPath(dir, 'foo/bar.txt');
+    expect(result).not.toBeNull();
+  });
+
+  it('rejects a relative path that escapes via ../', async () => {
+    const result = await resolveOutboundPath(dir, '../../../etc/passwd');
+    expect(result).toBeNull();
+  });
+
+  it('rejects a relative path that escapes via .. after valid prefix', async () => {
+    const result = await resolveOutboundPath(dir, 'subdir/../../../etc/passwd');
+    expect(result).toBeNull();
+  });
+
+  it('rejects an absolute path outside the base directory', async () => {
+    const result = await resolveOutboundPath(dir, '/etc/passwd');
+    expect(result).toBeNull();
+  });
+
+  it('accepts an absolute path that stays inside the base directory', async () => {
+    const absInside = resolve(dir, 'inside.txt');
+    const result = await resolveOutboundPath(dir, absInside);
+    expect(result).not.toBeNull();
+  });
+
+  it('resolves through realpath when the file exists (symlink to inside)', async () => {
+    const realFile = join(dir, 'real.txt');
+    await writeFile(realFile, 'hello');
+    const linkFile = join(dir, 'link.txt');
+    await symlink(realFile, linkFile);
+    const result = await resolveOutboundPath(dir, 'link.txt');
+    expect(result).not.toBeNull();
+  });
+
+  it('rejects a symlink that points outside the base directory', async () => {
+    const outsideTarget = join(tmpdir(), 'outside.txt');
+    await writeFile(outsideTarget, 'secret');
+    const linkFile = join(dir, 'escape-link.txt');
+    await symlink(outsideTarget, linkFile);
+    const result = await resolveOutboundPath(dir, 'escape-link.txt');
+    expect(result).toBeNull();
+  });
+
+  it('returns candidate path when file does not exist (no realpath)', async () => {
+    const result = await resolveOutboundPath(dir, 'nonexistent.png');
+    expect(result).not.toBeNull();
+  });
+
+  it('rejects a path inside the OS temp directory', async () => {
+    const tempFile = join(tmpdir(), 'golem-gen-image.png');
+    await writeFile(tempFile, 'tmp-data');
+    try {
+      const result = await resolveOutboundPath(dir, tempFile);
+      expect(result).toBeNull();
+    } finally {
+      await rm(tempFile, { force: true });
+    }
+  });
+
+  it('accepts a relative temp dir path resolved against baseDir (still inside baseDir)', async () => {
+    const result = await resolveOutboundPath(dir, 'still-inside.png');
+    expect(result).not.toBeNull();
+  });
+
+  it('rejects an absolute path inside the OS temp directory (different file)', async () => {
+    const tmpFile = join(tmpdir(), 'gen-abs-only-in-tmp.png');
+    await writeFile(tmpFile, 'tmp-content');
+    try {
+      const result = await resolveOutboundPath(dir, tmpFile);
+      expect(result).toBeNull();
+    } finally {
+      await rm(tmpFile, { force: true });
+    }
+  });
+
+  it('resolves a relative filename that exists only in the assistant dir', async () => {
+    const baseFile = join(dir, 'gen-only-in-base.png');
+    await writeFile(baseFile, 'base-content');
+    try {
+      const result = await resolveOutboundPath(dir, 'gen-only-in-base.png');
+      expect(result).not.toBeNull();
+      expect(result).toBe(await realpath(baseFile));
+    } finally {
+      await rm(baseFile, { force: true });
+    }
+  });
+
+  it('still rejects /etc/passwd (outside all allowed roots)', async () => {
+    const result = await resolveOutboundPath(dir, '/etc/passwd');
+    expect(result).toBeNull();
+  });
+
+  it('still rejects path that escapes via ../', async () => {
+    const result = await resolveOutboundPath(dir, '../../../etc/passwd');
+    expect(result).toBeNull();
+  });
+
+  it('rejects a file under POSIX /tmp (or /private/tmp on macOS)', async () => {
+    let tmpRoot = '/private/tmp';
+    try {
+      await writeFile(join(tmpRoot, 'golem-posix-tmp-file.png'), 'posix-tmp-data');
+    } catch {
+      tmpRoot = '/tmp';
+      await writeFile(join(tmpRoot, 'golem-posix-tmp-file.png'), 'posix-tmp-data');
+    }
+    const tmpFile = join(tmpRoot, 'golem-posix-tmp-file.png');
+    try {
+      const result = await resolveOutboundPath(dir, tmpFile);
+      expect(result).toBeNull();
+    } finally {
+      await rm(tmpFile, { force: true });
+    }
+  });
+
+  it('rejects an absolute path under /private/tmp (different root, file exists)', async () => {
+    const tmpFile = join('/private/tmp', 'golem-abs-posix-tmp.png');
+    const created = await writeFile(tmpFile, 'posix-abs-data').then(
+      () => true,
+      () => false,
+    );
+    try {
+      const result = await resolveOutboundPath(dir, tmpFile);
+      expect(result).toBeNull();
+    } finally {
+      if (created) await rm(tmpFile, { force: true });
+    }
+  });
+});
+
+// 鈹€鈹€ Gateway handleMessage media integration 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
+
+const mockAssistantStubs = {
+  setEngine(_e: string) {},
+  setModel(_m: string) {},
+  async getStatus() {
+    return {
+      config: { name: 'test', engine: 'mock' } as any,
+      skills: [] as never[],
+      engine: 'mock',
+      model: undefined,
+    };
+  },
+  async cancel(_k?: string) {
+    return true;
+  },
+  async resetSession(_k?: string) {},
+  async listModels() {
+    return ['mock-model-1', 'mock-model-2'];
+  },
+};
+
+type MockAssistant = {
+  chat(message: string, opts?: { sessionKey?: string }): AsyncIterable<StreamEvent>;
+  setEngine(engine: string): void;
+  setModel(model: string): void;
+  getStatus(): Promise<{
+    config: { name: string; engine: string };
+    skills: never[];
+    engine: string;
+    model: string | undefined;
+  }>;
+  cancel(sessionKey?: string): Promise<boolean>;
+  resetSession(sessionKey?: string): Promise<void>;
+  listModels(): Promise<string[]>;
+  callCount: number;
+  lastSessionKey: string | undefined;
+  lastPrompt: string | undefined;
+};
+
+function makeMockAssistant(replyText: string): MockAssistant {
+  const obj: MockAssistant = {
+    ...mockAssistantStubs,
+    callCount: 0,
+    lastSessionKey: undefined,
+    lastPrompt: undefined,
+    async *chat(message: string, opts: { sessionKey?: string } = {}) {
+      obj.callCount++;
+      obj.lastPrompt = message;
+      obj.lastSessionKey = opts.sessionKey;
+      yield { type: 'text' as const, content: replyText };
+      yield { type: 'done' as const, sessionId: 'mock-sid' };
+    },
+  };
+  return obj;
+}
+
+/** Scripted mock: returns next script on each chat call (last script repeats). */
+function makeScriptedAssistant(scripts: string[]): MockAssistant {
+  const obj: MockAssistant = {
+    ...mockAssistantStubs,
+    callCount: 0,
+    lastSessionKey: undefined,
+    lastPrompt: undefined,
+    async *chat(message: string, opts: { sessionKey?: string } = {}) {
+      const idx = obj.callCount++;
+      obj.lastPrompt = message;
+      obj.lastSessionKey = opts.sessionKey;
+      yield { type: 'text' as const, content: scripts[Math.min(idx, scripts.length - 1)] };
+      yield { type: 'done' as const, sessionId: 'mock-sid' };
+    },
+  };
+  return obj;
+}
+
+/** Streaming mock assistant that yields events in sequence. */
+function makeStreamingMockAssistant(events: StreamEvent[]): MockAssistant {
+  const obj: MockAssistant = {
+    ...mockAssistantStubs,
+    callCount: 0,
+    lastSessionKey: undefined,
+    lastPrompt: undefined,
+    async *chat(message: string, opts: { sessionKey?: string } = {}) {
+      obj.callCount++;
+      obj.lastPrompt = message;
+      obj.lastSessionKey = opts.sessionKey;
+      for (const e of events) {
+        yield e;
+      }
+    },
+  };
+  return obj;
+}
+
+type MockAdapter = {
+  replies: Array<{ msg: ChannelMessage; text: string }>;
+  mediaSends: Array<{
+    msg: ChannelMessage;
+    kind: 'image' | 'file';
+    fileName?: string;
+    size: number;
+  }>;
+  reply(msg: ChannelMessage, text: string): Promise<void>;
+  sendMedia?: (
+    msg: ChannelMessage,
+    media: { kind: 'image' | 'file'; data: Buffer; fileName?: string },
+  ) => Promise<void>;
+};
+
+function makeMockAdapter(withSendMedia: boolean): MockAdapter {
+  const obj: MockAdapter = {
+    replies: [],
+    mediaSends: [],
+    async reply(_msg: ChannelMessage, text: string) {
+      obj.replies.push({ msg: _msg, text });
+    },
+  };
+  if (withSendMedia) {
+    obj.sendMedia = async (msg: ChannelMessage, media) => {
+      obj.mediaSends.push({
+        msg,
+        kind: media.kind,
+        fileName: media.fileName,
+        size: media.data.length,
+      });
+    };
+  }
+  return obj;
+}
+
+function makeConfig(overrides: Partial<GolemConfig> = {}): GolemConfig {
+  return { name: 'golem', engine: 'cursor', ...overrides } as GolemConfig;
+}
+
+function makeDmMsg(overrides: Partial<ChannelMessage> = {}): ChannelMessage {
+  return {
+    channelType: 'slack',
+    senderId: 'U001',
+    senderName: 'alice',
+    chatId: 'C001',
+    chatType: 'dm',
+    text: 'hello',
+    raw: {},
+    ...overrides,
+  };
+}
+
+describe('handleMessage - media marker integration', () => {
+  let dir: string;
+  let handleMessage: typeof import('../gateway.js').handleMessage;
+  let groupHistories: Map<string, Array<{ senderName: string; text: string; isBot: boolean }>>;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'golem-mt-'));
+    const mod = await import('../gateway.js');
+    handleMessage = mod.handleMessage;
+    groupHistories = mod.groupHistories;
+    // Clear group histories between tests to avoid cross-test pollution
+    groupHistories.clear();
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('sends image via adapter.sendMedia and strips marker from text reply', async () => {
+    const imagePath = join(dir, 'test-image.png');
+    await writeFile(imagePath, Buffer.from('fake-png-data'));
+
+    const assistant = makeMockAssistant('Here is the chart:\n[SEND_IMAGE: test-image.png]\nLooks good?');
+    const adapter = makeMockAdapter(true);
+
+    await handleMessage(makeDmMsg(), makeConfig(), assistant, adapter, 'slack', false, dir);
+
+    const allText = adapter.replies.map((r) => r.text).join('\n');
+    expect(allText).toContain('Here is the chart:');
+    expect(allText).toContain('Looks good?');
+    expect(allText).not.toContain('[SEND_IMAGE:');
+
+    expect(adapter.mediaSends).toHaveLength(1);
+    expect(adapter.mediaSends[0].kind).toBe('image');
+    expect(adapter.mediaSends[0].fileName).toBe('test-image.png');
+    expect(adapter.mediaSends[0].size).toBe(13);
+  });
+
+  it('sends file via adapter.sendMedia with correct kind', async () => {
+    const filePath = join(dir, 'report.pdf');
+    await writeFile(filePath, Buffer.from('pdf-content'));
+
+    const assistant = makeMockAssistant('Here is the report:\n[SEND_FILE: report.pdf]');
+    const adapter = makeMockAdapter(true);
+
+    await handleMessage(makeDmMsg(), makeConfig(), assistant, adapter, 'slack', false, dir);
+
+    expect(adapter.mediaSends).toHaveLength(1);
+    expect(adapter.mediaSends[0].kind).toBe('file');
+    expect(adapter.mediaSends[0].fileName).toBe('report.pdf');
+    const allText = adapter.replies.map((r) => r.text).join('\n');
+    expect(allText).toContain('Here is the report:');
+  });
+
+  it('gracefully skips when adapter lacks sendMedia (strips marker, no error)', async () => {
+    const imagePath = join(dir, 'x.png');
+    await writeFile(imagePath, 'data');
+
+    const assistant = makeMockAssistant('text\n[SEND_IMAGE: x.png]\nmore');
+    const adapter = makeMockAdapter(false);
+
+    await handleMessage(makeDmMsg(), makeConfig(), assistant, adapter, 'slack', false, dir);
+
+    const allText = adapter.replies.map((r) => r.text).join('\n');
+    expect(allText).toContain('text');
+    expect(allText).toContain('more');
+    expect(allText).not.toContain('[SEND_IMAGE:');
+    expect(adapter.mediaSends).toHaveLength(0);
+  });
+
+  it('sends error notice when file is missing', async () => {
+    const assistant = makeMockAssistant('text\n[SEND_IMAGE: nonexistent.png]\nmore');
+    const adapter = makeMockAdapter(true);
+
+    await handleMessage(makeDmMsg(), makeConfig(), assistant, adapter, 'slack', false, dir);
+
+    expect(adapter.replies.some((r) => r.text.includes('无法发送'))).toBe(true);
+    expect(adapter.replies.some((r) => r.text.includes('nonexistent.png'))).toBe(true);
+    expect(adapter.mediaSends).toHaveLength(0);
+  });
+
+  it('sends error notice when image exceeds 10MB limit', async () => {
+    const bigPath = join(dir, 'big.png');
+    await writeFile(bigPath, Buffer.alloc(11 * 1024 * 1024));
+
+    const assistant = makeMockAssistant('[SEND_IMAGE: big.png]');
+    const adapter = makeMockAdapter(true);
+
+    await handleMessage(makeDmMsg(), makeConfig(), assistant, adapter, 'slack', false, dir);
+
+    expect(adapter.replies.some((r) => r.text.includes('10MB'))).toBe(true);
+    expect(adapter.mediaSends).toHaveLength(0);
+  });
+
+  it('sends error notice when file exceeds 20MB limit', async () => {
+    const bigPath = join(dir, 'big.bin');
+    await writeFile(bigPath, Buffer.alloc(21 * 1024 * 1024));
+
+    const assistant = makeMockAssistant('[SEND_FILE: big.bin]');
+    const adapter = makeMockAdapter(true);
+
+    await handleMessage(makeDmMsg(), makeConfig(), assistant, adapter, 'slack', false, dir);
+
+    expect(adapter.replies.some((r) => r.text.includes('20MB'))).toBe(true);
+    expect(adapter.mediaSends).toHaveLength(0);
+  });
+
+  it('sends error notice when path escapes assistant directory', async () => {
+    const assistant = makeMockAssistant('[SEND_FILE: ../../../etc/passwd]');
+    const adapter = makeMockAdapter(true);
+
+    await handleMessage(makeDmMsg(), makeConfig(), assistant, adapter, 'slack', false, dir);
+
+    expect(adapter.replies.some((r) => r.text.includes('路径超出助手目录范围'))).toBe(true);
+    expect(adapter.mediaSends).toHaveLength(0);
+  });
+
+  it('handles multiple media markers in one reply', async () => {
+    const imgPath = join(dir, 'a.png');
+    const filePath = join(dir, 'b.pdf');
+    await writeFile(imgPath, 'img-data');
+    await writeFile(filePath, 'file-data');
+
+    const assistant = makeMockAssistant('intro\n[SEND_IMAGE: a.png]\nmid\n[SEND_FILE: b.pdf]\noutro');
+    const adapter = makeMockAdapter(true);
+
+    await handleMessage(makeDmMsg(), makeConfig(), assistant, adapter, 'slack', false, dir);
+
+    expect(adapter.mediaSends).toHaveLength(2);
+    expect(adapter.mediaSends[0].kind).toBe('image');
+    expect(adapter.mediaSends[1].kind).toBe('file');
+    const allText = adapter.replies.map((r) => r.text).join('\n');
+    expect(allText).not.toContain('[SEND_IMAGE:');
+    expect(allText).not.toContain('[SEND_FILE:');
+    expect(allText).toContain('intro');
+    expect(allText).toContain('mid');
+    expect(allText).toContain('outro');
+  });
+
+  it('does NOT treat inline [SEND_IMAGE: ...] as a marker', async () => {
+    const assistant = makeMockAssistant('I will use [SEND_IMAGE: x.png] to explain.');
+    const adapter = makeMockAdapter(true);
+
+    await handleMessage(makeDmMsg(), makeConfig(), assistant, adapter, 'slack', false, dir);
+
+    expect(adapter.replies[0].text).toContain('[SEND_IMAGE: x.png]');
+    expect(adapter.mediaSends).toHaveLength(0);
+  });
+
+  it('media failure does not break the text reply', async () => {
+    const goodImg = join(dir, 'good.png');
+    await writeFile(goodImg, 'good-data');
+
+    const assistant = makeMockAssistant('start\n[SEND_IMAGE: good.png]\n[SEND_FILE: ../../../etc/passwd]\nend');
+    const adapter = makeMockAdapter(true);
+
+    await handleMessage(makeDmMsg(), makeConfig(), assistant, adapter, 'slack', false, dir);
+
+    expect(adapter.mediaSends).toHaveLength(1);
+    expect(adapter.mediaSends[0].fileName).toBe('good.png');
+    expect(adapter.replies.some((r) => r.text.includes('路径超出助手目录范围'))).toBe(true);
+  });
+
+  it('handles a reply consisting only of media markers (no text body)', async () => {
+    const img = join(dir, 'only.png');
+    await writeFile(img, 'data');
+
+    const assistant = makeMockAssistant('[SEND_IMAGE: only.png]');
+    const adapter = makeMockAdapter(true);
+
+    await handleMessage(makeDmMsg(), makeConfig(), assistant, adapter, 'slack', false, dir);
+
+    expect(adapter.mediaSends).toHaveLength(1);
+  });
+
+  it('handles buffered mode with media markers', async () => {
+    const img = join(dir, 'buf.png');
+    await writeFile(img, 'buf-data');
+
+    const assistant = makeMockAssistant('Result:\n[SEND_IMAGE: buf.png]');
+    const adapter = makeMockAdapter(true);
+
+    await handleMessage(makeDmMsg(), makeConfig(), assistant, adapter, 'slack', false, dir);
+
+    expect(adapter.mediaSends).toHaveLength(1);
+    const allText = adapter.replies.map((r) => r.text).join('\n');
+    expect(allText).toContain('Result:');
+  });
+
+  it('handles streaming mode with media markers', async () => {
+    const img = join(dir, 'stream.png');
+    await writeFile(img, 'stream-data');
+
+    const assistant = makeStreamingMockAssistant([
+      { type: 'text', content: 'First part.\n\n' },
+      { type: 'text', content: '[SEND_IMAGE: stream.png]\n\n' },
+      { type: 'text', content: 'Last part.' },
+      { type: 'done', sessionId: 'x' },
+    ]);
+    const adapter = makeMockAdapter(true);
+    const config = makeConfig({ streaming: { mode: 'streaming' } } as any);
+
+    await handleMessage(makeDmMsg(), config, assistant, adapter, 'slack', false, dir);
+
+    expect(adapter.mediaSends).toHaveLength(1);
+    expect(adapter.mediaSends[0].kind).toBe('image');
+    const allText = adapter.replies.map((r) => r.text).join('\n');
+    expect(allText).toContain('First part.');
+    expect(allText).toContain('Last part.');
+    expect(allText).not.toContain('[SEND_IMAGE:');
+  });
+
+  it('sendMedia error is caught and reported without breaking the pipeline', async () => {
+    const img = join(dir, 'err.png');
+    await writeFile(img, 'data');
+
+    const assistant = makeMockAssistant('text\n[SEND_IMAGE: err.png]\nmore');
+    const adapter = makeMockAdapter(true);
+    adapter.sendMedia = async () => {
+      throw new Error('upload rejected');
+    };
+
+    await handleMessage(makeDmMsg(), makeConfig(), assistant, adapter, 'slack', false, dir);
+
+    expect(adapter.replies.some((r) => r.text.includes('upload rejected'))).toBe(true);
+    const allText = adapter.replies.map((r) => r.text).join('\n');
+    expect(allText).toContain('text');
+    expect(allText).toContain('more');
+  });
+
+  it('interaction with [CONTINUE]: only sends media once, sentinel stripped', async () => {
+    const img = join(dir, 'cont.png');
+    await writeFile(img, 'data');
+
+    // First call returns [CONTINUE], second call returns plain text
+    const assistant = makeScriptedAssistant(['Working\n[SEND_IMAGE: cont.png]\n[CONTINUE]', 'All done.']);
+    const adapter = makeMockAdapter(true);
+
+    await handleMessage(makeDmMsg(), makeConfig(), assistant, adapter, 'slack', false, dir);
+
+    // Media sent only once (not re-sent on each auto-continue relay round)
+    expect(adapter.mediaSends).toHaveLength(1);
+    expect(adapter.mediaSends[0].fileName).toBe('cont.png');
+    const allText = adapter.replies.map((r) => r.text).join('\n');
+    expect(allText).not.toContain('[CONTINUE]');
+    expect(allText).not.toContain('[SEND_IMAGE:');
+    expect(allText).toContain('Working');
+    expect(allText).toContain('All done.');
+  });
+
+  it('does NOT leak media markers into group conversation history', async () => {
+    const img = join(dir, 'group_img.png');
+    await writeFile(img, 'group-data');
+
+    const assistant = makeMockAssistant('Hello team!\n[SEND_IMAGE: group_img.png]\nHow is everyone?');
+    const adapter = makeMockAdapter(true);
+
+    const groupMsg = makeDmMsg({ chatType: 'group', chatId: 'G001', text: '@golem hello' });
+    await handleMessage(groupMsg, makeConfig(), assistant, adapter, 'slack', false, dir);
+
+    // Group history must not contain media marker lines
+    const key = `${groupMsg.channelType}:${groupMsg.chatId}`;
+    const hist = groupHistories.get(key);
+    expect(hist).toBeDefined();
+    expect(hist!.length).toBeGreaterThan(0);
+    const botText = hist!.find((m) => m.isBot)?.text ?? '';
+    expect(botText).not.toContain('[SEND_IMAGE:');
+    expect(botText).not.toContain('[SEND_FILE:');
+    expect(botText).toContain('Hello team!');
+    expect(botText).toContain('How is everyone?');
+  });
+
+  it('streaming mode with [CONTINUE] + media: marker and CONTINUE stripped, media sent once', async () => {
+    const img = join(dir, 'cont_s.png');
+    await writeFile(img, 'sdata');
+
+    const assistant = makeStreamingMockAssistant([
+      { type: 'text', content: 'Working\n' },
+      { type: 'text', content: '[SEND_IMAGE: cont_s.png]\n' },
+      { type: 'text', content: '[CONTINUE]\n' },
+      { type: 'done', sessionId: 'x' },
+    ]);
+    const adapter = makeMockAdapter(true);
+    // Disable auto-continue so the relay loop does not re-invoke the mock
+    const config = makeConfig({ streaming: { mode: 'streaming' }, autoContinue: 0 } as any);
+
+    await handleMessage(makeDmMsg(), config, assistant, adapter, 'slack', false, dir);
+
+    expect(adapter.mediaSends).toHaveLength(1);
+    expect(adapter.mediaSends[0].kind).toBe('image');
+    const allText = adapter.replies.map((r) => r.text).join('\n');
+    expect(allText).not.toContain('[SEND_IMAGE:');
+    expect(allText).not.toContain('[CONTINUE]');
+    expect(allText).toContain('Working');
+  });
+});
+
+// 鈹€鈹€ MEDIA_MARKER_RE export 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
+
+describe('MEDIA_MARKER_RE', () => {
+  let MEDIA_MARKER_RE: RegExp;
+
+  beforeEach(async () => {
+    const mod = await import('../gateway.js');
+    MEDIA_MARKER_RE = mod.MEDIA_MARKER_RE;
+  });
+
+  /** Helper: test regex with fresh lastIndex to avoid global-flag state bleed. */
+  function testRe(text: string): boolean {
+    const re = new RegExp(MEDIA_MARKER_RE.source, MEDIA_MARKER_RE.flags);
+    return re.test(text);
+  }
+
+  it('matches a standalone SEND_IMAGE line', () => {
+    expect(testRe('[SEND_IMAGE: /tmp/photo.png]')).toBe(true);
+  });
+
+  it('matches a standalone SEND_FILE line', () => {
+    expect(testRe('[SEND_FILE: /tmp/report.pdf]')).toBe(true);
+  });
+
+  it('does not match inline sentinel in a sentence', () => {
+    expect(testRe('I will [SEND_IMAGE: x.png] now.')).toBe(false);
+  });
+
+  it('does not match sentinel without a path', () => {
+    expect(testRe('[SEND_IMAGE:]')).toBe(false);
+    expect(testRe('[SEND_FILE]')).toBe(false);
+  });
+
+  it('global flag finds multiple matches', () => {
+    const re = new RegExp(MEDIA_MARKER_RE.source, MEDIA_MARKER_RE.flags);
+    const text = '[SEND_IMAGE: a.png]\nmiddle\n[SEND_FILE: b.pdf]';
+    const matches = Array.from(text.matchAll(re));
+    expect(matches).toHaveLength(2);
+    expect(matches[0][1]).toBe('IMAGE');
+    expect(matches[1][1]).toBe('FILE');
+  });
+});
+
+// 鈹€鈹€ buildGroupPrompt injects MEDIA_PROTOCOL_HINT 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
+
+describe('buildGroupPrompt - MEDIA_PROTOCOL_HINT', () => {
+  let buildGroupPrompt: typeof import('../gateway.js').buildGroupPrompt;
+  let MEDIA_PROTOCOL_HINT: string;
+
+  beforeEach(async () => {
+    const mod = await import('../gateway.js');
+    buildGroupPrompt = mod.buildGroupPrompt;
+    MEDIA_PROTOCOL_HINT = mod.MEDIA_PROTOCOL_HINT;
+  });
+
+  it('includes MEDIA_PROTOCOL_HINT in group prompt output', () => {
+    const history: GroupMessage[] = [];
+    const prompt = buildGroupPrompt(
+      history,
+      'alice',
+      'send me a chart',
+      false, // injectPass
+      'slack-C001',
+      '/assistant',
+    );
+
+    expect(prompt).toContain('[SEND_IMAGE:');
+    expect(prompt).toContain(MEDIA_PROTOCOL_HINT);
+  });
+
+  it('includes MEDIA_PROTOCOL_HINT even with continue/pass/peers injected', () => {
+    const history: GroupMessage[] = [
+      { senderName: 'alice', text: 'hello', isBot: false },
+      { senderName: 'bob', text: 'hi there', isBot: false },
+    ];
+    const prompt = buildGroupPrompt(
+      history,
+      'alice',
+      'send the report',
+      true, // injectPass
+      'slack-C001',
+      '/assistant',
+      ['bob'], // othersAddressed
+      [{ name: 'peer-bot', role: 'reviewer' }], // peers
+      true, // injectContinue
+    );
+
+    expect(prompt).toContain('[SEND_IMAGE:');
+    expect(prompt).toContain(MEDIA_PROTOCOL_HINT);
+    expect(prompt).toContain('[CONTINUE]');
+  });
+});

--- a/src/__tests__/gateway-media.test.ts
+++ b/src/__tests__/gateway-media.test.ts
@@ -468,6 +468,8 @@ describe('handleMessage - media marker integration', () => {
     expect(allText).toContain('more');
     expect(allText).not.toContain('[SEND_IMAGE:');
     expect(adapter.mediaSends).toHaveLength(0);
+    // Degradation notice: the user must see why the image was not sent.
+    expect(allText).toContain('当前渠道不支持发送图片');
   });
 
   it('sends error notice when file is missing', async () => {

--- a/src/__tests__/gateway-media.test.ts
+++ b/src/__tests__/gateway-media.test.ts
@@ -763,6 +763,10 @@ describe('buildGroupPrompt - MEDIA_PROTOCOL_HINT', () => {
       false, // injectPass
       'slack-C001',
       '/assistant',
+      undefined, // othersAddressed
+      undefined, // peers
+      false, // injectContinue
+      true, // mediaHintSupported
     );
 
     expect(prompt).toContain('[SEND_IMAGE:');
@@ -784,6 +788,7 @@ describe('buildGroupPrompt - MEDIA_PROTOCOL_HINT', () => {
       ['bob'], // othersAddressed
       [{ name: 'peer-bot', role: 'reviewer' }], // peers
       true, // injectContinue
+      true, // mediaHintSupported
     );
 
     expect(prompt).toContain('[SEND_IMAGE:');

--- a/src/__tests__/gateway.test.ts
+++ b/src/__tests__/gateway.test.ts
@@ -400,6 +400,26 @@ describe('group chat helpers - buildGroupPrompt', () => {
     expect(result).not.toContain('Focus on your own domain expertise');
   });
 
+  it('includes MEDIA_PROTOCOL_HINT when mediaHintSupported is true (default)', () => {
+    const result = buildGroupPrompt([], 'alice', 'send me a chart', false, 'slack:C123', '');
+    expect(result).toContain('[SEND_IMAGE:');
+    expect(result).toContain('[SEND_FILE:');
+    expect(result).toContain('Do NOT use the message-push');
+    // Still includes other required content
+    expect(result).toContain('[Group: slack:C123');
+    expect(result).toContain('[alice] send me a chart');
+  });
+
+  it('excludes MEDIA_PROTOCOL_HINT when mediaHintSupported is false', () => {
+    const result = buildGroupPrompt([], 'alice', 'hello', false, 'slack:C123', '', undefined, undefined, false, false);
+    expect(result).not.toContain('[SEND_IMAGE:');
+    expect(result).not.toContain('[SEND_FILE:');
+    expect(result).not.toContain('Do NOT use the message-push');
+    // Still has other required content
+    expect(result).toContain('[Group: slack:C123');
+    expect(result).toContain('[alice] hello');
+  });
+
   it('DM uses per-user session key (buildSessionKey still works)', async () => {
     const { buildSessionKey } = await import('../channel.js');
     const msg: ChannelMessage = {
@@ -672,6 +692,74 @@ describe('DiscordAdapter', () => {
     const { DiscordAdapter } = await import('../channels/discord.js');
     const adapter = new (DiscordAdapter as any)({ botToken: 'fake-token' });
     await expect(adapter.stop()).resolves.toBeUndefined();
+  });
+});
+
+describe('processMedia - degradation notice for non-sendMedia channels', () => {
+  it('sends visible degradation notice when adapter lacks sendMedia', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'golem-sendmedia-'));
+    await mkdir(join(dir, 'temp_file'), { recursive: true });
+    // Create a small dummy file so it passes path/stat checks and reaches the sendMedia check
+    await writeFile(join(dir, 'temp_file', 'test.png'), Buffer.from('fake-png'));
+
+    const replies: string[] = [];
+
+    const assistant = {
+      async *chat(_text: string, _opts: { sessionKey: string }) {
+        yield { type: 'text' as const, content: 'Here is a chart\n[SEND_IMAGE: temp_file/test.png]' };
+        yield { type: 'done' as const, durationMs: 1 };
+      },
+      async setEngine() {},
+      async setModel() {},
+      async getStatus() {
+        return { engine: 'cursor', model: undefined, skills: [] };
+      },
+      async cancel() {
+        return false;
+      },
+      async resetSession() {},
+      async listModels() {
+        return [];
+      },
+    };
+
+    // Adapter WITHOUT sendMedia
+    const adapter = {
+      async reply(_msg: ChannelMessage, text: string) {
+        replies.push(text);
+      },
+    };
+
+    const msg: ChannelMessage = {
+      channelType: 'slack',
+      senderId: 'U001',
+      senderName: 'Alice',
+      chatId: 'C001',
+      chatType: 'group',
+      text: 'send me a chart',
+      mentioned: true,
+      raw: {},
+    };
+
+    try {
+      await handleMessage(
+        msg,
+        { name: 'GolemBot', engine: 'cursor' } as any,
+        assistant as any,
+        adapter,
+        'slack',
+        false,
+        dir,
+      );
+
+      // Assert the degradation notice was sent
+      const allReplies = replies.join('\n');
+      expect(allReplies).toContain('当前渠道不支持发送图片');
+      expect(allReplies).toContain('已忽略');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+      clearGroupChatState('slack:C001');
+    }
   });
 });
 

--- a/src/__tests__/gateway.test.ts
+++ b/src/__tests__/gateway.test.ts
@@ -786,3 +786,217 @@ describe('ReadReceipt', () => {
     expect(receipts[0]).toEqual({ messageId: 'msg-001', readerId: 'user-123' });
   });
 });
+
+describe('finalizeStatusUpdate error status text (issue #4)', () => {
+  it('passes ⚠️ Timed out (Xs) to clearStatus when agent times out with no partial output', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'golem-status-timeout-'));
+    const cleared: Array<{ statusId: string; finalText: string }> = [];
+    const replies: string[] = [];
+
+    const assistant = {
+      async *chat() {
+        yield { type: 'error' as const, message: 'Agent invocation timed out' };
+        yield {
+          type: 'completion' as const,
+          status: 'aborted' as const,
+          reason: 'timeout' as const,
+          partialText: undefined,
+        };
+      },
+      async setEngine() {},
+      async setModel() {},
+      async getStatus() {
+        return { engine: 'cursor', model: undefined, skills: [] };
+      },
+      async cancel() {
+        return false;
+      },
+      async resetSession() {},
+      async listModels() {
+        return [];
+      },
+    };
+
+    const adapter = {
+      async reply(_msg: ChannelMessage, text: string) {
+        replies.push(text);
+      },
+      async clearStatus(_msg: ChannelMessage, statusId: string, finalText = '') {
+        cleared.push({ statusId, finalText });
+      },
+    };
+
+    const msg: ChannelMessage = {
+      channelType: 'slack',
+      senderId: 'U001',
+      senderName: 'Alice',
+      chatId: 'C001',
+      chatType: 'dm',
+      text: 'trigger timeout',
+      raw: {},
+    };
+
+    try {
+      await handleMessage(
+        msg,
+        { name: 'GolemBot', engine: 'cursor', timeout: 1 } as any,
+        assistant as any,
+        adapter,
+        'slack',
+        false,
+        dir,
+      );
+      // finalizeStatusUpdate should route the ⚠️ Timed out status through clearStatus
+      expect(cleared.length).toBeGreaterThan(0);
+      expect(cleared[0].finalText).toBe('⚠️ Timed out (1s)');
+      // The user-facing reply must surface the specific outcome, not a generic error.
+      expect(replies.length).toBeGreaterThan(0);
+      expect(replies.join('\n')).toContain('Task timed out after 1s');
+      expect(replies.join('\n')).not.toContain('Sorry, an error occurred');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+      clearGroupChatState('slack:C001');
+    }
+  });
+
+  it('passes ⏹️ Stopped to clearStatus and user reply when agent is stopped by user with no partial output', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'golem-status-stop-'));
+    const cleared: Array<{ statusId: string; finalText: string }> = [];
+    const replies: string[] = [];
+
+    const assistant = {
+      async *chat() {
+        yield { type: 'error' as const, message: 'Agent invocation stopped by user' };
+        yield {
+          type: 'completion' as const,
+          status: 'aborted' as const,
+          reason: 'user' as const,
+          partialText: undefined,
+        };
+      },
+      async setEngine() {},
+      async setModel() {},
+      async getStatus() {
+        return { engine: 'cursor', model: undefined, skills: [] };
+      },
+      async cancel() {
+        return false;
+      },
+      async resetSession() {},
+      async listModels() {
+        return [];
+      },
+    };
+
+    const adapter = {
+      async reply(_msg: ChannelMessage, text: string) {
+        replies.push(text);
+      },
+      async clearStatus(_msg: ChannelMessage, statusId: string, finalText = '') {
+        cleared.push({ statusId, finalText });
+      },
+    };
+
+    const msg: ChannelMessage = {
+      channelType: 'slack',
+      senderId: 'U001',
+      senderName: 'Alice',
+      chatId: 'C001',
+      chatType: 'dm',
+      text: 'trigger stop',
+      raw: {},
+    };
+
+    try {
+      await handleMessage(
+        msg,
+        { name: 'GolemBot', engine: 'cursor' } as any,
+        assistant as any,
+        adapter,
+        'slack',
+        false,
+        dir,
+      );
+      expect(cleared.length).toBeGreaterThan(0);
+      expect(cleared[0].finalText).toBe('⏹️ Stopped');
+      // The user-facing reply must surface the specific outcome, not a generic error.
+      expect(replies.length).toBeGreaterThan(0);
+      expect(replies.join('\n')).toContain('The task was stopped before completion');
+      expect(replies.join('\n')).not.toContain('Sorry, an error occurred');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+      clearGroupChatState('slack:C001');
+    }
+  });
+
+  it('sends notice.reply and passes ⚠️ Timed out when agent times out with partial output', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'golem-status-partial-'));
+    const cleared: Array<{ statusId: string; finalText: string }> = [];
+    const replies: string[] = [];
+
+    const assistant = {
+      async *chat() {
+        yield {
+          type: 'completion' as const,
+          status: 'aborted' as const,
+          reason: 'timeout' as const,
+          partialText: 'Here is partial output',
+        };
+      },
+      async setEngine() {},
+      async setModel() {},
+      async getStatus() {
+        return { engine: 'cursor', model: undefined, skills: [] };
+      },
+      async cancel() {
+        return false;
+      },
+      async resetSession() {},
+      async listModels() {
+        return [];
+      },
+    };
+
+    const adapter = {
+      async reply(_msg: ChannelMessage, text: string) {
+        replies.push(text);
+      },
+      async clearStatus(_msg: ChannelMessage, statusId: string, finalText = '') {
+        cleared.push({ statusId, finalText });
+      },
+    };
+
+    const msg: ChannelMessage = {
+      channelType: 'slack',
+      senderId: 'U001',
+      senderName: 'Alice',
+      chatId: 'C001',
+      chatType: 'dm',
+      text: 'trigger timeout with partial',
+      raw: {},
+    };
+
+    try {
+      await handleMessage(
+        msg,
+        { name: 'GolemBot', engine: 'cursor', timeout: 1 } as any,
+        assistant as any,
+        adapter,
+        'slack',
+        false,
+        dir,
+      );
+      // Should send partial output + timeout notice reply
+      expect(replies.length).toBeGreaterThanOrEqual(1);
+      const allReplies = replies.join('\n');
+      expect(allReplies).toContain('Here is partial output');
+      expect(allReplies).toContain('timed out after 1s');
+      // finalizeStatusUpdate should route the ⚠️ Timed out status
+      expect(cleared.length).toBeGreaterThan(0);
+      expect(cleared[0].finalText).toBe('⚠️ Timed out (1s)');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+      clearGroupChatState('slack:C001');
+    }
+  });
+});

--- a/src/__tests__/gateway.test.ts
+++ b/src/__tests__/gateway.test.ts
@@ -400,8 +400,19 @@ describe('group chat helpers - buildGroupPrompt', () => {
     expect(result).not.toContain('Focus on your own domain expertise');
   });
 
-  it('includes MEDIA_PROTOCOL_HINT when mediaHintSupported is true (default)', () => {
-    const result = buildGroupPrompt([], 'alice', 'send me a chart', false, 'slack:C123', '');
+  it('includes MEDIA_PROTOCOL_HINT when mediaHintSupported is true', () => {
+    const result = buildGroupPrompt(
+      [],
+      'alice',
+      'send me a chart',
+      false,
+      'slack:C123',
+      '',
+      undefined,
+      undefined,
+      false,
+      true,
+    );
     expect(result).toContain('[SEND_IMAGE:');
     expect(result).toContain('[SEND_FILE:');
     expect(result).toContain('Do NOT use the message-push');

--- a/src/__tests__/gateway.test.ts
+++ b/src/__tests__/gateway.test.ts
@@ -288,7 +288,7 @@ describe('group chat helpers - buildGroupPrompt', () => {
 
   it('excludes [PASS] instruction when injectPass=false', () => {
     const result = buildGroupPrompt([], 'alice', 'hi', false, 'slack:C123', '');
-    expect(result).not.toContain('[System:');
+    expect(result).not.toContain('[PASS]');
   });
 
   it('formats current message as [senderName] text', () => {

--- a/src/__tests__/gateway.test.ts
+++ b/src/__tests__/gateway.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ChannelAdapter, ChannelMessage } from '../channel.js';
 import { detectMention } from '../channel.js';
 import {
@@ -923,6 +923,145 @@ describe('finalizeStatusUpdate error status text (issue #4)', () => {
       expect(replies.length).toBeGreaterThan(0);
       expect(replies.join('\n')).toContain('The task was stopped before completion');
       expect(replies.join('\n')).not.toContain('Sorry, an error occurred');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+      clearGroupChatState('slack:C001');
+    }
+  });
+
+  it('nativeStreaming: /stop closes the stream empty then sends ⏹️ Stopped separately', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'golem-status-native-stop-'));
+    const cleared: Array<{ statusId: string; finalText: string }> = [];
+    const replies: string[] = [];
+
+    const assistant = {
+      async *chat() {
+        yield { type: 'error' as const, message: 'Agent invocation stopped by user' };
+        yield {
+          type: 'completion' as const,
+          status: 'aborted' as const,
+          reason: 'user' as const,
+          partialText: undefined,
+        };
+      },
+      async setEngine() {},
+      async setModel() {},
+      async getStatus() {
+        return { engine: 'cursor', model: undefined, skills: [] };
+      },
+      async cancel() {
+        return false;
+      },
+      async resetSession() {},
+      async listModels() {
+        return [];
+      },
+    };
+
+    const adapter = {
+      nativeStreaming: true,
+      async reply(_msg: ChannelMessage, text: string) {
+        replies.push(text);
+      },
+      async clearStatus(_msg: ChannelMessage, statusId: string, finalText = '') {
+        cleared.push({ statusId, finalText });
+      },
+    };
+
+    const msg: ChannelMessage = {
+      channelType: 'slack',
+      senderId: 'U001',
+      senderName: 'Alice',
+      chatId: 'C001',
+      chatType: 'dm',
+      text: 'trigger stop',
+      raw: {},
+    };
+
+    vi.useFakeTimers();
+    try {
+      const promise = handleMessage(
+        msg,
+        { name: 'GolemBot', engine: 'cursor' } as any,
+        assistant as any,
+        adapter,
+        'slack',
+        false,
+        dir,
+      );
+      // advance past the 200ms isUserAbort delay so finalizeStatusUpdate completes
+      await vi.advanceTimersByTimeAsync(500);
+      await promise;
+      // The stream must be closed with EMPTY content first (loading stream closes silently).
+      expect(cleared.length).toBeGreaterThan(0);
+      expect(cleared[cleared.length - 1].finalText).toBe('');
+      // The ⏹️ Stopped finalText must be a separate user-visible message.
+      expect(replies).toContain('⏹️ Stopped');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+      clearGroupChatState('slack:C001');
+      vi.useRealTimers();
+    }
+  });
+
+  it('nativeStreaming: normal completion closes stream with ✅ Done inline (no separate message)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'golem-status-native-done-'));
+    const cleared: Array<{ statusId: string; finalText: string }> = [];
+    const replies: string[] = [];
+
+    const assistant = {
+      async *chat() {
+        yield { type: 'text' as const, content: 'All good' };
+        yield { type: 'done' as const, sessionId: 'x' };
+      },
+      async setEngine() {},
+      async setModel() {},
+      async getStatus() {
+        return { engine: 'cursor', model: undefined, skills: [] };
+      },
+      async cancel() {
+        return false;
+      },
+      async resetSession() {},
+      async listModels() {
+        return [];
+      },
+    };
+
+    const adapter = {
+      nativeStreaming: true,
+      async reply(_msg: ChannelMessage, text: string) {
+        replies.push(text);
+      },
+      async clearStatus(_msg: ChannelMessage, statusId: string, finalText = '') {
+        cleared.push({ statusId, finalText });
+      },
+    };
+
+    const msg: ChannelMessage = {
+      channelType: 'slack',
+      senderId: 'U001',
+      senderName: 'Alice',
+      chatId: 'C001',
+      chatType: 'dm',
+      text: 'hello',
+      raw: {},
+    };
+
+    try {
+      await handleMessage(
+        msg,
+        { name: 'GolemBot', engine: 'cursor' } as any,
+        assistant as any,
+        adapter,
+        'slack',
+        false,
+        dir,
+      );
+      // Normal completion: clearStatus closes the stream WITH the finalText inline.
+      expect(cleared.some((c) => c.finalText === '✅ Done')).toBe(true);
+      // No separate ⏹️/⚠️ final status message — finalText lives in the stream close.
+      expect(replies.some((r) => r.includes('⏹️') || r.includes('⚠️') || r.includes('✅'))).toBe(false);
     } finally {
       await rm(dir, { recursive: true, force: true });
       clearGroupChatState('slack:C001');

--- a/src/__tests__/opencode-stdin.test.ts
+++ b/src/__tests__/opencode-stdin.test.ts
@@ -54,6 +54,7 @@ describe('OpenCodeEngine prompt delivery (issue #43)', () => {
       return {
         ...original,
         isOnPath: () => true,
+        resolveOnPath: () => 'opencode',
         spawnCommand: vi.fn((_bin: string, args: string[]) => {
           capturedArgs = args;
           const ndjson = [

--- a/src/__tests__/opencode-stdin.test.ts
+++ b/src/__tests__/opencode-stdin.test.ts
@@ -5,6 +5,9 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { StreamEvent } from '../engine.js';
 
+// Expose findOpenCodeBin for testing via a hidden export in the module
+// (we will verify behaviour indirectly by mocking resolveOnPath)
+
 /**
  * Issue #43 — the prompt must be piped to opencode via stdin, never passed as
  * an argv element: multi-line prompts containing [System:] / [CONTINUE]
@@ -113,5 +116,105 @@ describe('OpenCodeEngine prompt delivery (issue #43)', () => {
 
     expect(events.some((e) => e.type === 'text' && e.content === 'ok')).toBe(true);
     expect(events.some((e) => e.type === 'done')).toBe(true);
+  });
+});
+
+describe('findOpenCodeBin Windows .exe direct path (issue #7)', () => {
+  let ws: string;
+  let capturedArgs: string[];
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ws = await mkdtemp(join(tmpdir(), 'golem-oc-exe-'));
+    capturedArgs = [];
+  });
+
+  afterEach(async () => {
+    vi.doUnmock('../engines/shared.js');
+    vi.doUnmock('node:fs');
+    vi.restoreAllMocks();
+    await rm(ws, { recursive: true, force: true });
+  });
+
+  it('returns the direct .exe path when npm global layout is detected', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const child = new StdinRecordingChild();
+    const capturedBin: string[] = [];
+    try {
+      vi.doMock('../engines/shared.js', async (importOriginal) => {
+        const original = await importOriginal<typeof import('../engines/shared.js')>();
+        return {
+          ...original,
+          resolveOnPath: vi.fn(() => 'C:\\Program Files\\nodejs\\opencode.ps1'),
+          spawnCommand: vi.fn((bin: string, args: string[]) => {
+            capturedBin.push(bin);
+            capturedArgs = args;
+            setTimeout(() => {
+              child.stdout.emit('data', Buffer.from(`\n`));
+              child.emit('close', 0);
+            }, 10);
+            return child;
+          }),
+        };
+      });
+      vi.doMock('node:fs', async (importOriginal) => {
+        const original = await importOriginal<typeof import('node:fs')>();
+        return {
+          ...original,
+          existsSync: vi.fn(
+            (p: string) => p === 'C:\\Program Files\\nodejs\\node_modules\\opencode-ai\\bin\\opencode.exe',
+          ),
+        };
+      });
+
+      const { OpenCodeEngine } = await import('../engines/opencode.js');
+      for await (const _evt of OpenCodeEngine.prototype.invoke('test', { workspace: ws, skillPaths: [] })) {
+        break;
+      }
+      expect(capturedBin[0]).toBe('C:\\Program Files\\nodejs\\node_modules\\opencode-ai\\bin\\opencode.exe');
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    }
+  });
+
+  it('falls back to "opencode" when .exe is absent', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const child = new StdinRecordingChild();
+    const capturedBin: string[] = [];
+    try {
+      vi.doMock('../engines/shared.js', async (importOriginal) => {
+        const original = await importOriginal<typeof import('../engines/shared.js')>();
+        return {
+          ...original,
+          resolveOnPath: vi.fn(() => 'C:\\Program Files\\nodejs\\opencode.cmd'),
+          spawnCommand: vi.fn((bin: string, args: string[]) => {
+            capturedBin.push(bin);
+            capturedArgs = args;
+            setTimeout(() => {
+              child.stdout.emit('data', Buffer.from(`\n`));
+              child.emit('close', 0);
+            }, 10);
+            return child;
+          }),
+        };
+      });
+      vi.doMock('node:fs', async (importOriginal) => {
+        const original = await importOriginal<typeof import('node:fs')>();
+        return {
+          ...original,
+          existsSync: vi.fn(() => false),
+        };
+      });
+
+      const { OpenCodeEngine } = await import('../engines/opencode.js');
+      for await (const _evt of OpenCodeEngine.prototype.invoke('test', { workspace: ws, skillPaths: [] })) {
+        break;
+      }
+      expect(capturedBin[0]).toBe('opencode');
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    }
   });
 });

--- a/src/__tests__/opencode-stdin.test.ts
+++ b/src/__tests__/opencode-stdin.test.ts
@@ -141,12 +141,14 @@ describe('findOpenCodeBin Windows .exe direct path (issue #7)', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const child = new StdinRecordingChild();
     const capturedBin: string[] = [];
+    const shimPath = join('C:\\Program Files\\nodejs', 'opencode.ps1');
+    const expectedExe = join('C:\\Program Files\\nodejs', 'node_modules', 'opencode-ai', 'bin', 'opencode.exe');
     try {
       vi.doMock('../engines/shared.js', async (importOriginal) => {
         const original = await importOriginal<typeof import('../engines/shared.js')>();
         return {
           ...original,
-          resolveOnPath: vi.fn(() => 'C:\\Program Files\\nodejs\\opencode.ps1'),
+          resolveOnPath: vi.fn(() => shimPath),
           spawnCommand: vi.fn((bin: string, args: string[]) => {
             capturedBin.push(bin);
             capturedArgs = args;
@@ -162,9 +164,7 @@ describe('findOpenCodeBin Windows .exe direct path (issue #7)', () => {
         const original = await importOriginal<typeof import('node:fs')>();
         return {
           ...original,
-          existsSync: vi.fn(
-            (p: string) => p === 'C:\\Program Files\\nodejs\\node_modules\\opencode-ai\\bin\\opencode.exe',
-          ),
+          existsSync: vi.fn((p: string) => p === expectedExe),
         };
       });
 
@@ -172,7 +172,7 @@ describe('findOpenCodeBin Windows .exe direct path (issue #7)', () => {
       for await (const _evt of OpenCodeEngine.prototype.invoke('test', { workspace: ws, skillPaths: [] })) {
         break;
       }
-      expect(capturedBin[0]).toBe('C:\\Program Files\\nodejs\\node_modules\\opencode-ai\\bin\\opencode.exe');
+      expect(capturedBin[0]).toBe(expectedExe);
     } finally {
       Object.defineProperty(process, 'platform', { value: originalPlatform });
     }

--- a/src/__tests__/wecom.test.ts
+++ b/src/__tests__/wecom.test.ts
@@ -328,6 +328,99 @@ describe('WecomAdapter', () => {
     });
   });
 
+  describe('per-chatId stream isolation', () => {
+    it('typing creates independent streams for different chatIds', async () => {
+      const msgA: ChannelMessage = {
+        channelType: 'wecom',
+        senderId: 'uA',
+        chatId: 'chat-A',
+        chatType: 'dm',
+        text: 'hi',
+        raw: { frameData: 'A' },
+      };
+      const msgB: ChannelMessage = {
+        channelType: 'wecom',
+        senderId: 'uB',
+        chatId: 'chat-B',
+        chatType: 'dm',
+        text: 'hi',
+        raw: { frameData: 'B' },
+      };
+
+      await adapter.typing(msgA);
+      await adapter.typing(msgB);
+
+      expect(mockReplyStream).toHaveBeenCalledTimes(2);
+      const [frameA, streamIdA] = mockReplyStream.mock.calls[0];
+      const [frameB, streamIdB] = mockReplyStream.mock.calls[1];
+      expect(frameA).toEqual({ frameData: 'A' });
+      expect(frameB).toEqual({ frameData: 'B' });
+      expect(streamIdA).toMatch(/^reply-\d+$/);
+      expect(streamIdB).toMatch(/^reply-\d+$/);
+    });
+
+    it('clearStatus only closes the stream for its own chatId', async () => {
+      const msgA: ChannelMessage = {
+        channelType: 'wecom',
+        senderId: 'uA',
+        chatId: 'chat-A',
+        chatType: 'dm',
+        text: 'hi',
+        raw: { frameData: 'A' },
+      };
+      const msgB: ChannelMessage = {
+        channelType: 'wecom',
+        senderId: 'uB',
+        chatId: 'chat-B',
+        chatType: 'dm',
+        text: 'hi',
+        raw: { frameData: 'B' },
+      };
+
+      await adapter.typing(msgA);
+      await adapter.typing(msgB);
+      mockReplyStream.mockClear();
+
+      await adapter.clearStatus(msgA, 'status-A');
+
+      // Should only close A's stream, not B's
+      expect(mockReplyStream).toHaveBeenCalledTimes(1);
+      const [closedFrame] = mockReplyStream.mock.calls[0];
+      expect(closedFrame).toEqual({ frameData: 'A' });
+    });
+
+    it('reply in one chatId does not close another chatId stream', async () => {
+      const msgA: ChannelMessage = {
+        channelType: 'wecom',
+        senderId: 'uA',
+        chatId: 'chat-A',
+        chatType: 'dm',
+        text: 'hi',
+        raw: { frameData: 'A' },
+      };
+      const msgB: ChannelMessage = {
+        channelType: 'wecom',
+        senderId: 'uB',
+        chatId: 'chat-B',
+        chatType: 'dm',
+        text: 'hi',
+        raw: { frameData: 'B' },
+      };
+
+      await adapter.typing(msgA);
+      mockReplyStream.mockClear();
+
+      await adapter.reply(msgB, 'Reply from B');
+
+      // Should send B's reply directly (no stream for B to close)
+      // Should NOT touch A's stream
+      expect(mockReplyStream).toHaveBeenCalledTimes(1);
+      const [frame, , text] = mockReplyStream.mock.calls[0];
+      expect(frame).toEqual({ frameData: 'B' });
+      expect(text).toBe('Reply from B');
+    });
+  });
+
   describe('getGroupMembers', () => {
     it('returns empty map for unknown chat', async () => {
       const members = await adapter.getGroupMembers('no-such-chat');

--- a/src/__tests__/wecom.test.ts
+++ b/src/__tests__/wecom.test.ts
@@ -313,7 +313,7 @@ describe('WecomAdapter', () => {
       raw: { frameData: 'original' },
     };
 
-    it('closes stream without hardcoded mission-complete text', async () => {
+    it('closes stream with default ✅ Done marker', async () => {
       await adapter.typing(msg); // opens loading stream
       mockReplyStream.mockClear();
 
@@ -322,9 +322,48 @@ describe('WecomAdapter', () => {
       expect(mockReplyStream).toHaveBeenCalledTimes(1);
       const callArgs = mockReplyStream.mock.calls[0];
       expect(callArgs[0]).toEqual({ frameData: 'original' });
-      expect(callArgs[2]).toBe('');
+      expect(callArgs[2]).toBe('✅ Done');
       expect(callArgs[3]).toBe(true);
       expect(callArgs[4]).toBeUndefined();
+    });
+
+    it('closes stream with custom finalText', async () => {
+      await adapter.typing(msg); // opens loading stream
+      mockReplyStream.mockClear();
+
+      await adapter.clearStatus(msg, 'status-1', '⚠️ Failed');
+
+      expect(mockReplyStream).toHaveBeenCalledTimes(1);
+      const callArgs = mockReplyStream.mock.calls[0];
+      expect(callArgs[2]).toBe('⚠️ Failed');
+      expect(callArgs[3]).toBe(true);
+    });
+
+    it('falls back to replyStream when no stream exists (final status not lost)', async () => {
+      mockReplyStream.mockClear();
+      mockSendMessage.mockClear();
+
+      // No typing()/reply() called first → no stream state for chatId.
+      // WeCom's aibot_send_msg rejects msgtype:'text' (errcode 40008), so the
+      // final status is delivered via replyStream on the incoming frame instead.
+      await adapter.clearStatus(msg, 'status-1', '⏹️ Stopped');
+
+      expect(mockSendMessage).not.toHaveBeenCalled();
+      expect(mockReplyStream).toHaveBeenCalledTimes(1);
+      const callArgs = mockReplyStream.mock.calls[0];
+      expect(callArgs[0]).toEqual({ frameData: 'original' });
+      expect(callArgs[2]).toBe('⏹️ Stopped');
+      expect(callArgs[3]).toBe(true);
+    });
+
+    it('does not send when no stream exists and finalText is the default ✅ Done', async () => {
+      mockReplyStream.mockClear();
+      mockSendMessage.mockClear();
+
+      await adapter.clearStatus(msg, 'status-1');
+
+      expect(mockReplyStream).not.toHaveBeenCalled();
+      expect(mockSendMessage).not.toHaveBeenCalled();
     });
   });
 
@@ -338,17 +377,13 @@ describe('WecomAdapter', () => {
       raw: { frameData: 'original' },
     };
 
-    it('sends the provided status text to the correct stream and closes it', async () => {
+    it('is a no-op and does not close the stream', async () => {
       await adapter.typing(msg); // opens loading stream
       mockReplyStream.mockClear();
 
       await adapter.updateStatus(msg, 'status-1', '\u26a0\ufe0f Failed');
 
-      expect(mockReplyStream).toHaveBeenCalledTimes(1);
-      const callArgs = mockReplyStream.mock.calls[0];
-      expect(callArgs[0]).toEqual({ frameData: 'original' });
-      expect(callArgs[2]).toBe('\u26a0\ufe0f Failed');
-      expect(callArgs[3]).toBe(true);
+      expect(mockReplyStream).not.toHaveBeenCalled();
     });
 
     it('no-ops when no stream exists for the chatId', async () => {
@@ -359,7 +394,7 @@ describe('WecomAdapter', () => {
       expect(mockReplyStream).not.toHaveBeenCalled();
     });
 
-    it('for one chatId does not affect another chatId stream', async () => {
+    it('does not affect streams for other chatIds', async () => {
       const msgA: ChannelMessage = {
         channelType: 'wecom',
         senderId: 'uA',
@@ -383,11 +418,25 @@ describe('WecomAdapter', () => {
 
       await adapter.updateStatus(msgA, 'status-A', '\u26a0\ufe0f Failed');
 
-      // Should only close A's stream, not B's
-      expect(mockReplyStream).toHaveBeenCalledTimes(1);
-      const [closedFrame, , closedText] = mockReplyStream.mock.calls[0];
-      expect(closedFrame).toEqual({ frameData: 'A' });
-      expect(closedText).toBe('\u26a0\ufe0f Failed');
+      // Should not call replyStream at all (no-op)
+      expect(mockReplyStream).not.toHaveBeenCalled();
+    });
+
+    it('after no-op updateStatus, reply() can still close the stream with real content', async () => {
+      await adapter.typing(msg); // opens loading stream
+      mockReplyStream.mockClear();
+
+      await adapter.updateStatus(msg, 'status-1', '\u26a0\ufe0f Failed'); // no-op
+      await adapter.reply(msg, 'Real answer');
+
+      // reply() closes the typing stream with real content and opens a new one
+      expect(mockReplyStream).toHaveBeenCalledTimes(2);
+      const [, , text0, isFinal0] = mockReplyStream.mock.calls[0];
+      const [, , text1, isFinal1] = mockReplyStream.mock.calls[1];
+      expect(text0).toBe('Real answer');
+      expect(isFinal0).toBe(true);
+      expect(text1).toBe('');
+      expect(isFinal1).toBe(false);
     });
   });
 
@@ -418,8 +467,9 @@ describe('WecomAdapter', () => {
       const [frameB, streamIdB] = mockReplyStream.mock.calls[1];
       expect(frameA).toEqual({ frameData: 'A' });
       expect(frameB).toEqual({ frameData: 'B' });
-      expect(streamIdA).toMatch(/^reply-\d+$/);
-      expect(streamIdB).toMatch(/^reply-\d+$/);
+      expect(streamIdA).toMatch(/^reply-\d+-\d+$/);
+      expect(streamIdB).toMatch(/^reply-\d+-\d+$/);
+      expect(streamIdA).not.toBe(streamIdB);
     });
 
     it('clearStatus only closes the stream for its own chatId', async () => {

--- a/src/__tests__/wecom.test.ts
+++ b/src/__tests__/wecom.test.ts
@@ -6,6 +6,9 @@ const mockConnect = vi.fn().mockResolvedValue(undefined);
 const mockDisconnect = vi.fn().mockResolvedValue(undefined);
 const mockReplyStream = vi.fn().mockResolvedValue(undefined);
 const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+const mockUploadMedia = vi.fn();
+const mockReplyMedia = vi.fn().mockResolvedValue(undefined);
+const mockSendMediaMessage = vi.fn().mockResolvedValue(undefined);
 // biome-ignore lint/complexity/noBannedTypes: mock handler map for test
 const handlers = new Map<string, Function>();
 const constructorArgs: any[] = [];
@@ -18,6 +21,9 @@ class MockWSClient {
   disconnect = mockDisconnect;
   replyStream = mockReplyStream;
   sendMessage = mockSendMessage;
+  uploadMedia = mockUploadMedia;
+  replyMedia = mockReplyMedia;
+  sendMediaMessage = mockSendMediaMessage;
   // biome-ignore lint/complexity/noBannedTypes: mock
   on(event: string, handler: Function) {
     handlers.set(event, handler);
@@ -201,23 +207,225 @@ describe('WecomAdapter', () => {
   });
 
   describe('reply', () => {
-    it('calls wsClient.replyStream with the frame', async () => {
-      const msg: ChannelMessage = {
-        channelType: 'wecom',
-        senderId: 'u1',
-        chatId: 'c1',
-        chatType: 'dm',
-        text: 'hi',
-        raw: { frameData: 'original' },
-      };
+    const msg: ChannelMessage = {
+      channelType: 'wecom',
+      senderId: 'u1',
+      chatId: 'c1',
+      chatType: 'dm',
+      text: 'hi',
+      raw: { frameData: 'original' },
+    };
 
+    it('without prior stream: sends text directly, no loading stream', async () => {
+      // no active stream (no typing before) → sends text directly
       await adapter.reply(msg, 'Reply text');
 
-      expect(mockReplyStream).toHaveBeenCalledOnce();
-      const [frame, _streamId, text, isFinal] = mockReplyStream.mock.calls[0];
+      expect(mockReplyStream).toHaveBeenCalledTimes(1);
+      const [frame, _s, text, isFinal] = mockReplyStream.mock.calls[0];
       expect(frame).toEqual({ frameData: 'original' });
       expect(text).toBe('Reply text');
       expect(isFinal).toBe(true);
+    });
+    it('replaces @Name with <@userid> in sent text', async () => {
+      await adapter.reply(msg, 'Thanks @Alice and @Bob!', {
+        mentions: [
+          { name: 'Alice', platformId: 'userid-alice' },
+          { name: 'Bob', platformId: 'userid-bob' },
+        ],
+      });
+
+      const [, , text] = mockReplyStream.mock.calls[0];
+      expect(text).toBe('Thanks <@userid-alice> and <@userid-bob>!');
+    });
+
+    it('escapes regex special characters in mention names', async () => {
+      await adapter.reply(msg, 'Hello @Dr.A+Smith', {
+        mentions: [{ name: 'Dr.A+Smith', platformId: 'userid-dr' }],
+      });
+
+      const [, , text] = mockReplyStream.mock.calls[0];
+      expect(text).toBe('Hello <@userid-dr>');
+    });
+
+    it('each reply closes old thinking and starts new one', async () => {
+      // Set up an active thinking stream first (simulate typing)
+      await adapter.typing(msg);
+      mockReplyStream.mockClear();
+
+      await adapter.reply(msg, 'Part 1');
+      // call 0: close typing stream with 'Part 1' (finish=true)
+      // call 1: start new thinking stream (finish=false)
+      expect(mockReplyStream).toHaveBeenCalledTimes(2);
+      const [, , text0, isFinal0] = mockReplyStream.mock.calls[0];
+      const [, , text1, isFinal1] = mockReplyStream.mock.calls[1];
+      expect(text0).toBe('Part 1');
+      expect(isFinal0).toBe(true);
+      expect(text1).toBe('');
+      expect(isFinal1).toBe(false);
+
+      mockReplyStream.mockClear();
+      await adapter.reply(msg, 'Part 2');
+      expect(mockReplyStream).toHaveBeenCalledTimes(2);
+      const [, , text2, isFinal2] = mockReplyStream.mock.calls[0];
+      expect(text2).toBe('Part 2');
+      expect(isFinal2).toBe(true);
+    });
+
+    it('ignores empty mentions array', async () => {
+      await adapter.reply(msg, 'Plain reply', { mentions: [] });
+
+      const [, , text, isFinal] = mockReplyStream.mock.calls[0];
+      expect(text).toBe('Plain reply');
+      expect(isFinal).toBe(true);
+    });
+
+    it('silently closes old stream when frame differs (cross-session)', async () => {
+      const msgA: ChannelMessage = { ...msg, raw: { frameData: 'sessionA' } };
+      const msgB: ChannelMessage = { ...msg, raw: { frameData: 'sessionB' } };
+
+      await adapter.typing(msgA); // opens stream on frameA
+      mockReplyStream.mockClear();
+
+      // reply from different session should close old stream silently, then open new
+      await adapter.reply(msgB, 'Msg from B');
+
+      expect(mockReplyStream).toHaveBeenCalledTimes(2);
+      // call 0: close old stream silently with empty text
+      const [f0, , text0, isFinal0] = mockReplyStream.mock.calls[0];
+      expect(f0).toEqual({ frameData: 'sessionA' });
+      expect(text0).toBe('');
+      expect(isFinal0).toBe(true);
+      // call 1: new stream sends text directly (no prior stream for sessionB)
+      const [f1, , text1, isFinal1] = mockReplyStream.mock.calls[1];
+      expect(f1).toEqual({ frameData: 'sessionB' });
+      expect(text1).toBe('Msg from B');
+      expect(isFinal1).toBe(true);
+    });
+  });
+
+  describe('clearStatus', () => {
+    const msg: ChannelMessage = {
+      channelType: 'wecom',
+      senderId: 'u1',
+      chatId: 'c1',
+      chatType: 'dm',
+      text: 'hi',
+      raw: { frameData: 'original' },
+    };
+
+    it('closes stream with mission complete\u2705 (no image msgItem)', async () => {
+      await adapter.typing(msg); // opens loading stream
+      mockReplyStream.mockClear();
+
+      await adapter.clearStatus(msg, 'status-1');
+
+      expect(mockReplyStream).toHaveBeenCalledTimes(1);
+      const callArgs = mockReplyStream.mock.calls[0];
+      expect(callArgs[0]).toEqual({ frameData: 'original' });
+      expect(callArgs[2]).toBe('mission complete \u2705');
+      expect(callArgs[3]).toBe(true);
+      expect(callArgs[4]).toBeUndefined();
+    });
+  });
+
+  describe('getGroupMembers', () => {
+    it('returns empty map for unknown chat', async () => {
+      const members = await adapter.getGroupMembers('no-such-chat');
+      expect(members.size).toBe(0);
+    });
+
+    it('accumulates name→userid mapping from group frames', async () => {
+      const textHandler = handlers.get('message.text')!;
+      textHandler({
+        msgId: 'gm-1',
+        userId: 'userid-alice',
+        userName: 'Alice',
+        chatId: 'group-1',
+        chatType: 'group',
+        content: { text: 'hello' },
+      });
+      textHandler({
+        body: {
+          msgid: 'gm-2',
+          from: { userid: 'userid-bob' },
+          from_name: 'Bob',
+          chattype: 'group',
+          chatid: 'group-1',
+          text: { content: 'hi all' },
+        },
+      });
+
+      const members = await adapter.getGroupMembers('group-1');
+      expect(members.get('Alice')).toBe('userid-alice');
+      expect(members.get('Bob')).toBe('userid-bob');
+      expect(members.size).toBe(2);
+    });
+
+    it('does not cache senders from DM frames', async () => {
+      const textHandler = handlers.get('message.text')!;
+      textHandler({
+        msgId: 'dm-1',
+        userId: 'userid-carol',
+        userName: 'Carol',
+        chatId: 'dm-chat',
+        chatType: 'dm',
+        content: { text: 'hi' },
+      });
+
+      const members = await adapter.getGroupMembers('dm-chat');
+      expect(members.size).toBe(0);
+    });
+
+    it('expires member cache after TTL', async () => {
+      vi.useFakeTimers();
+      try {
+        const textHandler = handlers.get('message.text')!;
+        textHandler({
+          msgId: 'gm-ttl',
+          userId: 'userid-dave',
+          userName: 'Dave',
+          chatId: 'group-ttl',
+          chatType: 'group',
+          content: { text: 'hello' },
+        });
+
+        expect((await adapter.getGroupMembers('group-ttl')).get('Dave')).toBe('userid-dave');
+
+        vi.setSystemTime(Date.now() + 11 * 60 * 1000);
+        expect((await adapter.getGroupMembers('group-ttl')).size).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe('typing', () => {
+    const msg: ChannelMessage = {
+      channelType: 'wecom',
+      senderId: 'u1',
+      chatId: 'chat-1',
+      chatType: 'dm',
+      text: 'hi',
+      raw: {},
+    };
+
+    it('calls wsClient.sendTyping when supported', async () => {
+      const mockSendTyping = vi.fn().mockResolvedValue(undefined);
+      (adapter as any).wsClient.sendTyping = mockSendTyping;
+
+      await adapter.typing(msg);
+
+      expect(mockSendTyping).toHaveBeenCalledWith('chat-1');
+    });
+
+    it('no-ops when SDK does not support typing', async () => {
+      await expect(adapter.typing(msg)).resolves.toBeUndefined();
+    });
+
+    it('swallows errors from sendTyping', async () => {
+      (adapter as any).wsClient.sendTyping = vi.fn().mockRejectedValue(new Error('not supported'));
+
+      await expect(adapter.typing(msg)).resolves.toBeUndefined();
     });
   });
 
@@ -230,6 +438,169 @@ describe('WecomAdapter', () => {
         msgtype: 'text',
         text: { content: 'Proactive message' },
       });
+    });
+  });
+
+  describe('sendMedia', () => {
+    const msg: ChannelMessage = {
+      channelType: 'wecom',
+      senderId: 'u1',
+      chatId: 'chat-1',
+      chatType: 'dm',
+      text: 'hi',
+      raw: { frameData: 'incoming-frame' },
+    };
+
+    const smallImage = Buffer.alloc(100);
+    const smallFile = Buffer.alloc(200);
+
+    beforeEach(() => {
+      mockUploadMedia.mockReset();
+      mockReplyMedia.mockReset();
+      mockSendMediaMessage.mockReset();
+    });
+
+    it('sendMedia image: uploads with correct Buffer + metadata and calls replyMedia (all formats)', async () => {
+      mockUploadMedia.mockResolvedValue({
+        type: 'image',
+        media_id: 'media-img-1',
+        created_at: '2025-01-01T00:00:00Z',
+      });
+
+      const pngImage = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x01, 0x02, 0x03, 0x04, 0x05]);
+
+      await adapter.sendMedia(msg, { kind: 'image', data: pngImage, fileName: 'chart.png' });
+
+      expect(mockUploadMedia).toHaveBeenCalledOnce();
+      expect(mockUploadMedia).toHaveBeenCalledWith(pngImage, { type: 'image', filename: 'chart.png' });
+      expect(mockReplyMedia).toHaveBeenCalledOnce();
+      expect(mockReplyMedia).toHaveBeenCalledWith({ frameData: 'incoming-frame' }, 'image', 'media-img-1');
+      expect(mockSendMediaMessage).not.toHaveBeenCalled();
+    });
+
+    it('sendMedia JPEG image: goes through uploadMedia + replyMedia (no inline path)', async () => {
+      mockUploadMedia.mockResolvedValue({
+        type: 'image',
+        media_id: 'media-jpg-1',
+        created_at: '2025-01-01T00:00:00Z',
+      });
+
+      const jpgImage = Buffer.from([0xff, 0xd8, 0xff, 0x01, 0x02]);
+
+      await adapter.sendMedia(msg, { kind: 'image', data: jpgImage, fileName: 'photo.jpg' });
+
+      expect(mockUploadMedia).toHaveBeenCalledOnce();
+      expect(mockUploadMedia).toHaveBeenCalledWith(jpgImage, { type: 'image', filename: 'photo.jpg' });
+      expect(mockReplyMedia).toHaveBeenCalledOnce();
+      expect(mockReplyMedia).toHaveBeenCalledWith({ frameData: 'incoming-frame' }, 'image', 'media-jpg-1');
+      expect(mockSendMediaMessage).not.toHaveBeenCalled();
+    });
+
+    it('sendMedia file: uploads with correct Buffer + metadata and calls replyMedia', async () => {
+      mockUploadMedia.mockResolvedValue({
+        type: 'file',
+        media_id: 'media-file-1',
+        created_at: '2025-01-01T00:00:00Z',
+      });
+
+      await adapter.sendMedia(msg, { kind: 'file', data: smallFile, fileName: 'doc.pdf' });
+
+      expect(mockUploadMedia).toHaveBeenCalledOnce();
+      expect(mockUploadMedia).toHaveBeenCalledWith(smallFile, { type: 'file', filename: 'doc.pdf' });
+      expect(mockReplyMedia).toHaveBeenCalledOnce();
+      expect(mockReplyMedia).toHaveBeenCalledWith({ frameData: 'incoming-frame' }, 'file', 'media-file-1');
+      expect(mockSendMediaMessage).not.toHaveBeenCalled();
+    });
+
+    it('sendMedia image without fileName defaults to image.png', async () => {
+      mockUploadMedia.mockResolvedValue({
+        type: 'image',
+        media_id: 'media-default-img',
+        created_at: '2025-01-01T00:00:00Z',
+      });
+
+      await adapter.sendMedia(msg, { kind: 'image', data: smallImage });
+
+      expect(mockUploadMedia).toHaveBeenCalledWith(smallImage, { type: 'image', filename: 'image.png' });
+    });
+
+    it('sendMedia file without fileName defaults to attachment.bin', async () => {
+      mockUploadMedia.mockResolvedValue({
+        type: 'file',
+        media_id: 'media-default-file',
+        created_at: '2025-01-01T00:00:00Z',
+      });
+
+      await adapter.sendMedia(msg, { kind: 'file', data: smallFile });
+
+      expect(mockUploadMedia).toHaveBeenCalledWith(smallFile, { type: 'file', filename: 'attachment.bin' });
+    });
+
+    it('sendMedia image < 5 bytes throws', async () => {
+      const tiny = Buffer.from([0x89, 0x50, 0x4e]); // 3 bytes (below 5-byte minimum)
+
+      await expect(adapter.sendMedia(msg, { kind: 'image', data: tiny })).rejects.toThrow(
+        /too small.*3 bytes.*minimum is 5/i,
+      );
+      expect(mockUploadMedia).not.toHaveBeenCalled();
+    });
+
+    it('sendMedia file < 5 bytes throws', async () => {
+      const tiny = Buffer.from([0x01, 0x02, 0x03]); // 3 bytes
+
+      await expect(adapter.sendMedia(msg, { kind: 'file', data: tiny })).rejects.toThrow(
+        /too small.*3 bytes.*minimum is 5/i,
+      );
+      expect(mockUploadMedia).not.toHaveBeenCalled();
+    });
+
+    it('oversized image (>10MB) rejects, uploadMedia NOT called', async () => {
+      const oversized = Buffer.alloc(10 * 1024 * 1024 + 1);
+
+      await expect(adapter.sendMedia(msg, { kind: 'image', data: oversized })).rejects.toThrow(
+        /too large.*image.*10\.0MB.*maximum is 10MB/i,
+      );
+      expect(mockUploadMedia).not.toHaveBeenCalled();
+    });
+
+    it('oversized file (>20MB) rejects, uploadMedia NOT called', async () => {
+      const oversized = Buffer.alloc(20 * 1024 * 1024 + 1);
+
+      await expect(adapter.sendMedia(msg, { kind: 'file', data: oversized })).rejects.toThrow(
+        /too large.*file.*20\.0MB.*maximum is 20MB/i,
+      );
+      expect(mockUploadMedia).not.toHaveBeenCalled();
+    });
+
+    it('msg.raw undefined → falls back to sendMediaMessage', async () => {
+      mockUploadMedia.mockResolvedValue({
+        type: 'image',
+        media_id: 'media-fallback',
+        created_at: '2025-01-01T00:00:00Z',
+      });
+
+      const noRawMsg: ChannelMessage = {
+        channelType: 'wecom',
+        senderId: 'u1',
+        chatId: 'chat-proactive',
+        chatType: 'dm',
+        text: 'hi',
+        raw: undefined,
+      };
+
+      await adapter.sendMedia(noRawMsg, { kind: 'image', data: smallImage });
+
+      expect(mockUploadMedia).toHaveBeenCalledOnce();
+      expect(mockReplyMedia).not.toHaveBeenCalled();
+      expect(mockSendMediaMessage).toHaveBeenCalledOnce();
+      expect(mockSendMediaMessage).toHaveBeenCalledWith('chat-proactive', 'image', 'media-fallback');
+    });
+
+    it('wsClient null → resolves silently', async () => {
+      await adapter.stop(); // sets wsClient to null
+
+      await expect(adapter.sendMedia(msg, { kind: 'image', data: smallImage })).resolves.toBeUndefined();
+      expect(mockUploadMedia).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/wecom.test.ts
+++ b/src/__tests__/wecom.test.ts
@@ -313,7 +313,7 @@ describe('WecomAdapter', () => {
       raw: { frameData: 'original' },
     };
 
-    it('closes stream with mission complete\u2705 (no image msgItem)', async () => {
+    it('closes stream without hardcoded mission-complete text', async () => {
       await adapter.typing(msg); // opens loading stream
       mockReplyStream.mockClear();
 
@@ -322,9 +322,72 @@ describe('WecomAdapter', () => {
       expect(mockReplyStream).toHaveBeenCalledTimes(1);
       const callArgs = mockReplyStream.mock.calls[0];
       expect(callArgs[0]).toEqual({ frameData: 'original' });
-      expect(callArgs[2]).toBe('mission complete \u2705');
+      expect(callArgs[2]).toBe('');
       expect(callArgs[3]).toBe(true);
       expect(callArgs[4]).toBeUndefined();
+    });
+  });
+
+  describe('updateStatus', () => {
+    const msg: ChannelMessage = {
+      channelType: 'wecom',
+      senderId: 'u1',
+      chatId: 'c1',
+      chatType: 'dm',
+      text: 'hi',
+      raw: { frameData: 'original' },
+    };
+
+    it('sends the provided status text to the correct stream and closes it', async () => {
+      await adapter.typing(msg); // opens loading stream
+      mockReplyStream.mockClear();
+
+      await adapter.updateStatus(msg, 'status-1', '\u26a0\ufe0f Failed');
+
+      expect(mockReplyStream).toHaveBeenCalledTimes(1);
+      const callArgs = mockReplyStream.mock.calls[0];
+      expect(callArgs[0]).toEqual({ frameData: 'original' });
+      expect(callArgs[2]).toBe('\u26a0\ufe0f Failed');
+      expect(callArgs[3]).toBe(true);
+    });
+
+    it('no-ops when no stream exists for the chatId', async () => {
+      mockReplyStream.mockClear();
+
+      await adapter.updateStatus(msg, 'status-1', '\u26a0\ufe0f Failed');
+
+      expect(mockReplyStream).not.toHaveBeenCalled();
+    });
+
+    it('for one chatId does not affect another chatId stream', async () => {
+      const msgA: ChannelMessage = {
+        channelType: 'wecom',
+        senderId: 'uA',
+        chatId: 'chat-A',
+        chatType: 'dm',
+        text: 'hi',
+        raw: { frameData: 'A' },
+      };
+      const msgB: ChannelMessage = {
+        channelType: 'wecom',
+        senderId: 'uB',
+        chatId: 'chat-B',
+        chatType: 'dm',
+        text: 'hi',
+        raw: { frameData: 'B' },
+      };
+
+      await adapter.typing(msgA);
+      await adapter.typing(msgB);
+      mockReplyStream.mockClear();
+
+      await adapter.updateStatus(msgA, 'status-A', '\u26a0\ufe0f Failed');
+
+      // Should only close A's stream, not B's
+      expect(mockReplyStream).toHaveBeenCalledTimes(1);
+      const [closedFrame, , closedText] = mockReplyStream.mock.calls[0];
+      expect(closedFrame).toEqual({ frameData: 'A' });
+      expect(closedText).toBe('\u26a0\ufe0f Failed');
     });
   });
 

--- a/src/__tests__/workspace.test.ts
+++ b/src/__tests__/workspace.test.ts
@@ -378,6 +378,18 @@ describe('workspace', () => {
       const content = await readFile(join(dir, 'AGENTS.md'), 'utf-8');
       expect(content).not.toContain('## Persona');
     });
+
+    it('always regenerates AGENTS.md when called again with different skills', async () => {
+      // First call creates AGENTS.md with skillA
+      await generateAgentsMd(dir, [{ name: 'skill-a', path: '/tmp/a', description: 'First skill' }]);
+
+      // Second call with different skills must overwrite the existing file
+      await generateAgentsMd(dir, [{ name: 'skill-b', path: '/tmp/b', description: 'Second skill' }]);
+
+      const content = await readFile(join(dir, 'AGENTS.md'), 'utf-8');
+      expect(content).toContain('- skill-b: Second skill');
+      expect(content).not.toContain('- skill-a: First skill');
+    });
   });
 
   // ── ensureReady ───────────────────────────────────

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -62,6 +62,15 @@ export interface ReplyOptions {
   mentions?: MentionTarget[];
 }
 
+/** A media payload the bot SENDS to a chat (image or file). */
+export interface OutboundMedia {
+  kind: 'image' | 'file';
+  /** Raw media bytes. */
+  data: Buffer;
+  /** Optional original filename (used for upload metadata). */
+  fileName?: string;
+}
+
 /**
  * Read receipt emitted when a user reads a message sent by the bot.
  * Currently only supported by Feishu (via `im.message.message_read_v1` event).
@@ -87,6 +96,12 @@ export interface ChannelAdapter {
    * Not all adapters support this — check before calling.
    */
   send?(chatId: string, text: string): Promise<void>;
+  /**
+   * Optional: send an image or file attachment to the chat that `msg` came from.
+   * Used by the gateway when the agent emits a SEND_IMAGE/SEND_FILE protocol marker.
+   * Adapters that cannot send media simply omit this method — the gateway degrades gracefully.
+   */
+  sendMedia?(msg: ChannelMessage, media: OutboundMedia): Promise<void>;
   /**
    * Optional: send a "typing…" indicator to the chat.
    * Called before a long-running AI invocation so the user sees immediate feedback.

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -87,6 +87,12 @@ export interface ChannelAdapter {
   readonly name: string;
   /** Optional: override the default 4000-char message split limit for this channel. */
   readonly maxMessageLength?: number;
+  /**
+   * Optional: adapter manages its own streaming state (e.g. WeCom native loading UI).
+   * When true, the gateway skips intermediate status updates and routes the final
+   * status through clearStatus(msg, statusId, finalText).
+   */
+  readonly nativeStreaming?: boolean;
   start(onMessage: (msg: ChannelMessage) => void | Promise<void>): Promise<void>;
   reply(msg: ChannelMessage, text: string, options?: ReplyOptions): Promise<void>;
   stop(): Promise<void>;
@@ -116,7 +122,7 @@ export interface ChannelAdapter {
   /** Optional: update a previously created status/progress message. */
   updateStatus?(msg: ChannelMessage, statusId: string, text: string): Promise<void>;
   /** Optional: clear a previously created status/progress message. */
-  clearStatus?(msg: ChannelMessage, statusId: string): Promise<void>;
+  clearStatus?(msg: ChannelMessage, statusId: string, finalText?: string): Promise<void>;
   /**
    * Optional: resolve group members for @mention support.
    * Returns a map of display name → platform-specific user ID.

--- a/src/channels/wecom.ts
+++ b/src/channels/wecom.ts
@@ -1,4 +1,4 @@
-import type { ChannelAdapter, ChannelMessage, ReplyOptions } from '../channel.js';
+import type { ChannelAdapter, ChannelMessage, OutboundMedia, ReplyOptions } from '../channel.js';
 import { importPeer } from '../peer-require.js';
 import type { WecomChannelConfig } from '../workspace.js';
 
@@ -9,6 +9,13 @@ export class WecomAdapter implements ChannelAdapter {
   private wsClient: any = null;
   private seenMsgIds = new Set<string>();
   private static readonly MAX_SEEN = 500;
+  /** chatId -> (display name -> userid), accumulated from incoming group frames. */
+  private groupMemberCache = new Map<string, Map<string, string>>();
+  private static readonly MEMBER_CACHE_TTL = 10 * 60 * 1000;
+  private groupMemberCacheTime = new Map<string, number>();
+  private activeStreamId: string | null = null;
+  private activeStreamFrame: any = null;
+  private activeStreamTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(config: WecomChannelConfig) {
     this.config = config;
@@ -72,32 +79,154 @@ export class WecomAdapter implements ChannelAdapter {
     const chatType = body.chattype || body.chatType || body.chat_type;
     const isGroup = chatType === 'group';
     const chatId = body.chatid || body.chatId || body.conversation_id || (!isGroup ? senderId : '');
+    const senderName: string | undefined = body.userName || body.from_name;
+
+    if (isGroup && chatId && senderId && senderName) {
+      let members = this.groupMemberCache.get(chatId);
+      if (!members) {
+        members = new Map();
+        this.groupMemberCache.set(chatId, members);
+      }
+      members.set(senderName, senderId);
+      this.groupMemberCacheTime.set(chatId, Date.now());
+    }
 
     const channelMsg: ChannelMessage = {
       channelType: 'wecom',
       senderId,
-      senderName: body.userName || body.from_name,
+      senderName,
       chatId,
       chatType: isGroup ? 'group' : 'dm',
       text,
       messageId: msgId,
-      mentioned: body.mentioned,
+      mentioned: isGroup ? true : undefined,
       raw: frame,
     };
 
     onMessage(channelMsg);
   }
 
-  async reply(msg: ChannelMessage, text: string, _options?: ReplyOptions): Promise<void> {
+  async getGroupMembers(chatId: string): Promise<Map<string, string>> {
+    // WeCom Smart Bot does not expose a member list API; return the cache
+    // accumulated from incoming group frames in handleFrame.
+    const cached = this.groupMemberCache.get(chatId);
+    if (!cached) return new Map();
+    const ts = this.groupMemberCacheTime.get(chatId) ?? 0;
+    if (Date.now() - ts >= WecomAdapter.MEMBER_CACHE_TTL) {
+      this.groupMemberCache.delete(chatId);
+      this.groupMemberCacheTime.delete(chatId);
+      return new Map();
+    }
+    return cached;
+  }
+
+  async reply(msg: ChannelMessage, text: string, options?: ReplyOptions): Promise<void> {
     if (!this.wsClient) return;
     const frame = msg.raw;
-    const streamId = `reply-${Date.now()}`;
-    await this.wsClient.replyStream(frame, streamId, text, true);
+
+    let processedText = text;
+    const mentions = options?.mentions;
+    if (mentions && mentions.length > 0) {
+      for (const m of mentions) {
+        processedText = processedText.replace(
+          new RegExp(`@${m.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'g'),
+          `<@${m.platformId}>`,
+        );
+      }
+    }
+
+    // Close current stream and send reply text
+    if (this.activeStreamId && this.activeStreamFrame) {
+      if (this.activeStreamFrame !== frame) {
+        // Cross-conversation (group<->dm): silently close old stream, then process new message
+        this.wsClient.replyStream(this.activeStreamFrame, this.activeStreamId, '', true).catch(() => {});
+        this.activeStreamId = null;
+        this.activeStreamFrame = null;
+        // Falls through to else branch below to create new stream
+      } else {
+        this.wsClient.replyStream(this.activeStreamFrame, this.activeStreamId, processedText, true).catch(() => {});
+        // Immediately open new empty stream (WeCom native loading UI)
+        this.activeStreamId = `reply-${Date.now()}`;
+        this.activeStreamFrame = frame;
+        this.wsClient.replyStream(frame, this.activeStreamId, '', false).catch(() => {});
+      }
+    }
+    if (!this.activeStreamId) {
+      // No previous stream (slash command etc.), send directly without opening new loading stream
+      const streamId = `reply-${Date.now()}`;
+      this.wsClient.replyStream(frame, streamId, processedText, true).catch(() => {});
+    }
+    if (this.activeStreamTimer) {
+      clearTimeout(this.activeStreamTimer);
+      this.activeStreamTimer = null;
+    }
+  }
+
+  async sendStatus(_msg: ChannelMessage, _text: string): Promise<string> {
+    // Don't send visible message (WeCom native loading UI is sufficient), only return status ID to maintain gateway lifecycle
+    return `silent-${Date.now()}`;
+  }
+
+  async clearStatus(_msg: ChannelMessage, _statusId: string): Promise<void> {
+    if (this.activeStreamTimer) {
+      clearTimeout(this.activeStreamTimer);
+      this.activeStreamTimer = null;
+    }
+    if (this.activeStreamId && this.activeStreamFrame && this.wsClient) {
+      this.wsClient
+        .replyStream(this.activeStreamFrame, this.activeStreamId, 'mission complete \u2705', true)
+        .catch(() => {});
+    }
+    this.activeStreamId = null;
+    this.activeStreamFrame = null;
+  }
+
+  async typing(msg: ChannelMessage): Promise<void> {
+    if (!this.wsClient) return;
+    try {
+      await this.wsClient.sendTyping?.(msg.chatId);
+    } catch {}
+    if (!this.activeStreamId) {
+      this.activeStreamId = `reply-${Date.now()}`;
+      this.activeStreamFrame = msg.raw;
+      this.wsClient.replyStream(msg.raw, this.activeStreamId, '', false).catch(() => {});
+    }
   }
 
   async send(chatId: string, text: string): Promise<void> {
     if (!this.wsClient) return;
     await this.wsClient.sendMessage(chatId, { msgtype: 'text', text: { content: text } });
+  }
+
+  async sendMedia(msg: ChannelMessage, media: OutboundMedia): Promise<void> {
+    if (!this.wsClient) return;
+
+    const minSize = 5;
+    if (media.data.length < minSize) {
+      throw new Error(`Media too small: file is ${media.data.length} bytes, minimum is ${minSize} bytes`);
+    }
+
+    const maxSize = media.kind === 'image' ? 10 * 1024 * 1024 : 20 * 1024 * 1024;
+    if (media.data.length > maxSize) {
+      const kindLabel = media.kind === 'image' ? 'image' : 'file';
+      const maxMB = media.kind === 'image' ? 10 : 20;
+      throw new Error(
+        `Media too large: ${kindLabel} is ${(media.data.length / (1024 * 1024)).toFixed(1)}MB, maximum is ${maxMB}MB`,
+      );
+    }
+
+    const filename = media.fileName ?? (media.kind === 'image' ? 'image.png' : 'attachment.bin');
+
+    const upload = await this.wsClient.uploadMedia(media.data, {
+      type: media.kind,
+      filename,
+    });
+
+    if (msg.raw) {
+      await this.wsClient.replyMedia(msg.raw, media.kind, upload.media_id);
+    } else {
+      await this.wsClient.sendMediaMessage(msg.chatId, media.kind, upload.media_id);
+    }
   }
 
   async stop(): Promise<void> {

--- a/src/channels/wecom.ts
+++ b/src/channels/wecom.ts
@@ -2,6 +2,12 @@ import type { ChannelAdapter, ChannelMessage, OutboundMedia, ReplyOptions } from
 import { importPeer } from '../peer-require.js';
 import type { WecomChannelConfig } from '../workspace.js';
 
+interface StreamState {
+  streamId: string;
+  frame: any;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
 export class WecomAdapter implements ChannelAdapter {
   readonly name = 'wecom';
   readonly maxMessageLength = 2048;
@@ -13,9 +19,7 @@ export class WecomAdapter implements ChannelAdapter {
   private groupMemberCache = new Map<string, Map<string, string>>();
   private static readonly MEMBER_CACHE_TTL = 10 * 60 * 1000;
   private groupMemberCacheTime = new Map<string, number>();
-  private activeStreamId: string | null = null;
-  private activeStreamFrame: any = null;
-  private activeStreamTimer: ReturnType<typeof setTimeout> | null = null;
+  private streams = new Map<string, StreamState>();
 
   constructor(config: WecomChannelConfig) {
     this.config = config;
@@ -135,30 +139,28 @@ export class WecomAdapter implements ChannelAdapter {
       }
     }
 
-    // Close current stream and send reply text
-    if (this.activeStreamId && this.activeStreamFrame) {
-      if (this.activeStreamFrame !== frame) {
+    const state = this.streams.get(msg.chatId);
+    if (state) {
+      if (state.frame !== frame) {
         // Cross-conversation (group<->dm): silently close old stream, then process new message
-        this.wsClient.replyStream(this.activeStreamFrame, this.activeStreamId, '', true).catch(() => {});
-        this.activeStreamId = null;
-        this.activeStreamFrame = null;
-        // Falls through to else branch below to create new stream
+        this.wsClient.replyStream(state.frame, state.streamId, '', true).catch(() => {});
+        this.streams.delete(msg.chatId);
+        // Falls through to no-state branch below to send directly
       } else {
-        this.wsClient.replyStream(this.activeStreamFrame, this.activeStreamId, processedText, true).catch(() => {});
+        this.wsClient.replyStream(state.frame, state.streamId, processedText, true).catch(() => {});
         // Immediately open new empty stream (WeCom native loading UI)
-        this.activeStreamId = `reply-${Date.now()}`;
-        this.activeStreamFrame = frame;
-        this.wsClient.replyStream(frame, this.activeStreamId, '', false).catch(() => {});
+        const newStreamId = `reply-${Date.now()}`;
+        this.streams.set(msg.chatId, { streamId: newStreamId, frame, timer: null });
+        this.wsClient.replyStream(frame, newStreamId, '', false).catch(() => {});
       }
     }
-    if (!this.activeStreamId) {
+    if (!this.streams.has(msg.chatId)) {
       // No previous stream (slash command etc.), send directly without opening new loading stream
       const streamId = `reply-${Date.now()}`;
       this.wsClient.replyStream(frame, streamId, processedText, true).catch(() => {});
     }
-    if (this.activeStreamTimer) {
-      clearTimeout(this.activeStreamTimer);
-      this.activeStreamTimer = null;
+    if (state?.timer) {
+      clearTimeout(state.timer);
     }
   }
 
@@ -168,17 +170,15 @@ export class WecomAdapter implements ChannelAdapter {
   }
 
   async clearStatus(_msg: ChannelMessage, _statusId: string): Promise<void> {
-    if (this.activeStreamTimer) {
-      clearTimeout(this.activeStreamTimer);
-      this.activeStreamTimer = null;
+    const state = this.streams.get(_msg.chatId);
+    if (!state) return;
+    if (state.timer) {
+      clearTimeout(state.timer);
     }
-    if (this.activeStreamId && this.activeStreamFrame && this.wsClient) {
-      this.wsClient
-        .replyStream(this.activeStreamFrame, this.activeStreamId, 'mission complete \u2705', true)
-        .catch(() => {});
+    if (this.wsClient) {
+      this.wsClient.replyStream(state.frame, state.streamId, 'mission complete \u2705', true).catch(() => {});
     }
-    this.activeStreamId = null;
-    this.activeStreamFrame = null;
+    this.streams.delete(_msg.chatId);
   }
 
   async typing(msg: ChannelMessage): Promise<void> {
@@ -186,10 +186,11 @@ export class WecomAdapter implements ChannelAdapter {
     try {
       await this.wsClient.sendTyping?.(msg.chatId);
     } catch {}
-    if (!this.activeStreamId) {
-      this.activeStreamId = `reply-${Date.now()}`;
-      this.activeStreamFrame = msg.raw;
-      this.wsClient.replyStream(msg.raw, this.activeStreamId, '', false).catch(() => {});
+    const state = this.streams.get(msg.chatId);
+    if (!state) {
+      const streamId = `reply-${Date.now()}`;
+      this.streams.set(msg.chatId, { streamId, frame: msg.raw, timer: null });
+      this.wsClient.replyStream(msg.raw, streamId, '', false).catch(() => {});
     }
   }
 

--- a/src/channels/wecom.ts
+++ b/src/channels/wecom.ts
@@ -11,6 +11,7 @@ interface StreamState {
 export class WecomAdapter implements ChannelAdapter {
   readonly name = 'wecom';
   readonly maxMessageLength = 2048;
+  readonly nativeStreaming = true;
   private config: WecomChannelConfig;
   private wsClient: any = null;
   private seenMsgIds = new Set<string>();
@@ -20,6 +21,7 @@ export class WecomAdapter implements ChannelAdapter {
   private static readonly MEMBER_CACHE_TTL = 10 * 60 * 1000;
   private groupMemberCacheTime = new Map<string, number>();
   private streams = new Map<string, StreamState>();
+  private streamSeq = 0;
 
   constructor(config: WecomChannelConfig) {
     this.config = config;
@@ -149,14 +151,14 @@ export class WecomAdapter implements ChannelAdapter {
       } else {
         this.wsClient.replyStream(state.frame, state.streamId, processedText, true).catch(() => {});
         // Immediately open new empty stream (WeCom native loading UI)
-        const newStreamId = `reply-${Date.now()}`;
+        const newStreamId = `reply-${Date.now()}-${++this.streamSeq}`;
         this.streams.set(msg.chatId, { streamId: newStreamId, frame, timer: null });
         this.wsClient.replyStream(frame, newStreamId, '', false).catch(() => {});
       }
     }
     if (!this.streams.has(msg.chatId)) {
       // No previous stream (slash command etc.), send directly without opening new loading stream
-      const streamId = `reply-${Date.now()}`;
+      const streamId = `reply-${Date.now()}-${++this.streamSeq}`;
       this.wsClient.replyStream(frame, streamId, processedText, true).catch(() => {});
     }
     if (state?.timer) {
@@ -169,26 +171,36 @@ export class WecomAdapter implements ChannelAdapter {
     return `silent-${Date.now()}`;
   }
 
-  async updateStatus(msg: ChannelMessage, _statusId: string, text: string): Promise<void> {
-    const state = this.streams.get(msg.chatId);
-    if (!state) return;
-    if (state.timer) {
-      clearTimeout(state.timer);
-    }
-    if (this.wsClient) {
-      this.wsClient.replyStream(state.frame, state.streamId, text, true).catch(() => {});
-    }
-    this.streams.delete(msg.chatId);
+  async updateStatus(_msg: ChannelMessage, _statusId: string, _text: string): Promise<void> {
+    // No-op: WeCom's native loading UI is sufficient for intermediate status
+    // updates (thinking, replying, tool hints). The stream stays open so
+    // reply() can continue its close-and-reopen cycle per chunk.
   }
 
-  async clearStatus(msg: ChannelMessage, _statusId: string): Promise<void> {
+  async clearStatus(msg: ChannelMessage, _statusId: string, finalText = '✅ Done'): Promise<void> {
     const state = this.streams.get(msg.chatId);
-    if (!state) return;
+    if (!state) {
+      // No open stream (e.g. task aborted before any chunk was sent): still
+      // surface the final status text so ⏹️ Stopped / ⚠️ Timed out are not lost.
+      // WeCom's aibot_send_msg rejects msgtype:'text' (errcode 40008), so reply
+      // via the incoming frame's response_url instead.
+      if (finalText && finalText !== '✅ Done' && this.wsClient) {
+        if (msg.raw) {
+          const streamId = `reply-${Date.now()}-${++this.streamSeq}`;
+          await this.wsClient.replyStream(msg.raw, streamId, finalText, true).catch(() => {});
+        } else {
+          await this.wsClient
+            .sendMessage(msg.chatId, { msgtype: 'text', text: { content: finalText } })
+            .catch(() => {});
+        }
+      }
+      return;
+    }
     if (state.timer) {
       clearTimeout(state.timer);
     }
     if (this.wsClient) {
-      this.wsClient.replyStream(state.frame, state.streamId, '', true).catch(() => {});
+      this.wsClient.replyStream(state.frame, state.streamId, finalText, true).catch(() => {});
     }
     this.streams.delete(msg.chatId);
   }
@@ -200,7 +212,7 @@ export class WecomAdapter implements ChannelAdapter {
     } catch {}
     const state = this.streams.get(msg.chatId);
     if (!state) {
-      const streamId = `reply-${Date.now()}`;
+      const streamId = `reply-${Date.now()}-${++this.streamSeq}`;
       this.streams.set(msg.chatId, { streamId, frame: msg.raw, timer: null });
       this.wsClient.replyStream(msg.raw, streamId, '', false).catch(() => {});
     }

--- a/src/channels/wecom.ts
+++ b/src/channels/wecom.ts
@@ -169,16 +169,28 @@ export class WecomAdapter implements ChannelAdapter {
     return `silent-${Date.now()}`;
   }
 
-  async clearStatus(_msg: ChannelMessage, _statusId: string): Promise<void> {
-    const state = this.streams.get(_msg.chatId);
+  async updateStatus(msg: ChannelMessage, _statusId: string, text: string): Promise<void> {
+    const state = this.streams.get(msg.chatId);
     if (!state) return;
     if (state.timer) {
       clearTimeout(state.timer);
     }
     if (this.wsClient) {
-      this.wsClient.replyStream(state.frame, state.streamId, 'mission complete \u2705', true).catch(() => {});
+      this.wsClient.replyStream(state.frame, state.streamId, text, true).catch(() => {});
     }
-    this.streams.delete(_msg.chatId);
+    this.streams.delete(msg.chatId);
+  }
+
+  async clearStatus(msg: ChannelMessage, _statusId: string): Promise<void> {
+    const state = this.streams.get(msg.chatId);
+    if (!state) return;
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+    if (this.wsClient) {
+      this.wsClient.replyStream(state.frame, state.streamId, '', true).catch(() => {});
+    }
+    this.streams.delete(msg.chatId);
   }
 
   async typing(msg: ChannelMessage): Promise<void> {

--- a/src/channels/wecom.ts
+++ b/src/channels/wecom.ts
@@ -207,15 +207,17 @@ export class WecomAdapter implements ChannelAdapter {
 
   async typing(msg: ChannelMessage): Promise<void> {
     if (!this.wsClient) return;
-    try {
-      await this.wsClient.sendTyping?.(msg.chatId);
-    } catch {}
+    // Open the loading stream FIRST so the user sees the loading UI immediately.
+    // sendTyping is optional and may be slow/unsupported — don't block the stream on it.
     const state = this.streams.get(msg.chatId);
     if (!state) {
       const streamId = `reply-${Date.now()}-${++this.streamSeq}`;
       this.streams.set(msg.chatId, { streamId, frame: msg.raw, timer: null });
       this.wsClient.replyStream(msg.raw, streamId, '', false).catch(() => {});
     }
+    try {
+      await this.wsClient.sendTyping?.(msg.chatId);
+    } catch {}
   }
 
   async send(chatId: string, text: string): Promise<void> {

--- a/src/engines/opencode.ts
+++ b/src/engines/opencode.ts
@@ -1,9 +1,10 @@
+import { existsSync } from 'node:fs';
 import { lstat, mkdir, readdir, readFile, symlink, unlink, writeFile } from 'node:fs/promises';
-import { basename, join, resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { debugEventLog, isDebugEventsEnabled, summarizeJsonEventLine } from '../debug-events.js';
 import type { AgentEngine, InvokeOpts, ListModelsOpts, StreamEvent } from '../engine.js';
 import { openCodeProviderEnv } from './provider-env.js';
-import { isOnPath, spawnCommand } from './shared.js';
+import { resolveOnPath, spawnCommand } from './shared.js';
 
 // ── Provider env resolution ──────────────────────────────
 
@@ -236,12 +237,23 @@ export async function ensureOpenCodeConfig(
 // ── Engine ───────────────────────────────────────────────
 
 function findOpenCodeBin(): string {
-  if (!isOnPath('opencode')) {
+  const resolved = resolveOnPath('opencode');
+  if (!resolved) {
     throw new Error(
       `OpenCode CLI ("opencode") not found in PATH\n` +
         `Install it with: npm install -g opencode-ai\n` +
         `See: https://opencode.ai/docs`,
     );
+  }
+  // Windows: npm global installs place a .cmd/.ps1 shim that forwards to
+  // node_modules/opencode-ai/bin/opencode.exe.  Using the .exe directly
+  // avoids PowerShell -File stdin encoding issues (CJK garbled on GBK systems).
+  if (process.platform === 'win32') {
+    const shimDir = dirname(resolved);
+    const exeDirect = join(shimDir, 'node_modules', 'opencode-ai', 'bin', 'opencode.exe');
+    if (existsSync(exeDirect)) {
+      return exeDirect;
+    }
   }
   return 'opencode';
 }

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -299,6 +299,8 @@ export function buildGroupPrompt(
   peers?: PeerBot[],
   /** When true, inject the turn-end contract so the agent signals unfinished work with [CONTINUE]. */
   injectContinue = false,
+  /** When true (default), inject the media protocol hint so agents know how to send images/files. */
+  mediaHintSupported = true,
 ): string {
   const parts: string[] = [];
 
@@ -306,9 +308,12 @@ export function buildGroupPrompt(
     parts.push(TURN_END_CONTRACT);
   }
 
-  // Always inject media protocol hint into group prompts so agents remember
-  // how to send images/files even when the prompt is large and dilutes skill guidance.
-  parts.push(MEDIA_PROTOCOL_HINT);
+  // Inject media protocol hint only when the channel adapter supports sendMedia.
+  // Otherwise, agents on non-sendMedia channels receive a visible degradation
+  // notice in processMedia instead.
+  if (mediaHintSupported) {
+    parts.push(MEDIA_PROTOCOL_HINT);
+  }
 
   if (injectPass) {
     const base =
@@ -585,11 +590,13 @@ export async function handleMessage(
       othersAddressed,
       peers,
       relayEnabled,
+      !!adapter.sendMedia,
     );
   } else {
     sessionKey = buildSessionKey(msg);
     const dmParts = [`[System: This is a private 1-on-1 conversation with ${senderLabel}.]`];
     if (relayEnabled) dmParts.push(TURN_END_CONTRACT);
+    if (adapter.sendMedia) dmParts.push(MEDIA_PROTOCOL_HINT);
     dmParts.push(msg.text);
     fullText = dmParts.join('\n');
   }
@@ -724,6 +731,8 @@ export async function handleMessage(
         }
 
         if (!adapter.sendMedia) {
+          const label = marker.kind === 'image' ? '图片' : '文件';
+          await sendChunk(`⚠️ 当前渠道不支持发送${label}，已忽略`);
           log(verbose, `[${channelType}] adapter lacks sendMedia, skipping ${marker.kind} ${marker.path}`);
           continue;
         }

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -529,10 +529,28 @@ export async function handleMessage(
       scheduler: cronCtx?.scheduler,
       runTask: cronCtx?.runTask,
     };
+
+    // Open the native loading stream immediately so the user sees feedback
+    // while the command executes (not after).
+    const isStop = parsed.name === 'stop';
+    if (adapter.typing && !isStop) {
+      await adapter.typing(msg).catch(() => {});
+    }
+
     const result = await executeCommand(parsed, cmdCtx);
     if (result) {
       log(verbose, `[${channelType}] slash command: ${parsed.name}`);
-      await adapter.reply(msg, result.text);
+      if (isStop) {
+        // /stop is special: the aborted handler owns the finalText (⏹️ Stopped).
+        await adapter.reply(msg, result.text);
+      } else if (adapter.typing && adapter.clearStatus) {
+        // executeCommand may have been fast — ensure the loading is visible
+        // for at least 200ms before closing with the command output.
+        await new Promise<void>((r) => setTimeout(r, 200));
+        await adapter.clearStatus(msg, '', result.text.trim()).catch(() => {});
+      } else {
+        await adapter.reply(msg, result.text);
+      }
       return;
     }
     // Unknown command — fall through to agent
@@ -682,7 +700,7 @@ export async function handleMessage(
     await adapter.reply(msg, text.trim());
   };
 
-  const finalizeStatusUpdate = async (finalText = '✅ Done'): Promise<void> => {
+  const finalizeStatusUpdate = async (finalText = '✅ Done', isUserAbort = false): Promise<void> => {
     cancelThinkingStatus();
     // Skip only when neither a status message exists nor the adapter has clearStatus.
     // Adapters that support streaming (e.g. WeCom) need clearStatus called even without
@@ -690,9 +708,20 @@ export async function handleMessage(
     if (!statusMessageId && !adapter.clearStatus) return;
     debugEventLog(debugEventsEnabled, `[event-debug] gateway status-final textChars=${finalText.length}`);
     if (adapter.nativeStreaming && adapter.clearStatus) {
-      const currentStatusId = statusMessageId;
-      statusMessageId = undefined;
-      await adapter.clearStatus(msg, currentStatusId ?? '', finalText);
+      if (isUserAbort) {
+        // /stop: close the stream without writing content, let the slash
+        // handler's "Stopped the current task." land first, then send the
+        // ⏹️ Stopped finalText as a separate message.
+        await adapter.clearStatus(msg, statusMessageId ?? '', '').catch(() => {});
+        await new Promise(r => setTimeout(r, 200));
+        await adapter.reply(msg, finalText).catch(() => {});
+      } else {
+        // Normal completion / timeout / generic failure: keep the original
+        // behavior — clearStatus closes the stream with the finalText inline.
+        const currentStatusId = statusMessageId;
+        statusMessageId = undefined;
+        await adapter.clearStatus(msg, currentStatusId ?? '', finalText);
+      }
       statusFinalized = true;
       return;
     }
@@ -997,7 +1026,7 @@ export async function handleMessage(
       const { body, hasContinue } = splitTrailingContinue(mediaStrippedReply);
       const willRelay = hasContinue && mayRelay && !hasError;
       if (fullReply.trim()) {
-        if (!willRelay) await finalizeStatusUpdate(finalStatusText ?? '✅ Done');
+        if (!willRelay) await finalizeStatusUpdate(finalStatusText ?? '✅ Done', lastErrorMessage === 'Agent invocation stopped by user');
         log(verbose, `[${channelType}] replied to ${senderLabel}: "${fullReply.trim().slice(0, 80)}..." (streaming)`);
         trackMetrics({ responsePreview: body.trim().slice(0, 120) });
       }
@@ -1084,7 +1113,7 @@ export async function handleMessage(
           }
           finalStatusText = notice.status;
         }
-        if (!willRelay) await finalizeStatusUpdate(finalStatusText ?? '✅ Done');
+        if (!willRelay) await finalizeStatusUpdate(finalStatusText ?? '✅ Done', lastErrorMessage === 'Agent invocation stopped by user');
         log(verbose, `[${channelType}] replied to ${senderLabel}: "${fullReply.trim().slice(0, 80)}..."`);
         trackMetrics({ responsePreview: body.trim().slice(0, 120) });
       }

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -75,22 +75,34 @@ function summarizeToolCall(name: string, args: string, maxLen = 72): string {
   return `🔧 ${label} ${preview}`;
 }
 
-function buildErrorNotice(errorMessage: string, timeoutSeconds: number): { reply: string; status: string } {
+function buildErrorNotice(
+  errorMessage: string,
+  timeoutSeconds: number,
+  hasPartialOutput: boolean,
+): { reply: string; status: string } {
   if (/stopped by user/i.test(errorMessage)) {
     return {
-      reply: 'The task was stopped before completion. The partial reply above may be incomplete.',
+      reply: hasPartialOutput
+        ? 'The task was stopped before completion. The partial reply above may be incomplete.'
+        : 'The task was stopped before completion.',
       status: '⏹️ Stopped',
     };
   }
   if (/timed out/i.test(errorMessage)) {
     return {
-      reply: `Task timed out after ${timeoutSeconds}s. The partial reply above may be incomplete.`,
+      reply: hasPartialOutput
+        ? `Task timed out after ${timeoutSeconds}s. The partial reply above may be incomplete.`
+        : `Task timed out after ${timeoutSeconds}s.`,
       status: `⚠️ Timed out (${timeoutSeconds}s)`,
     };
   }
+  const detail = errorMessage.trim().replace(/\s+/g, ' ').slice(0, 200);
+  if (detail) {
+    return { reply: detail, status: '⚠️ Failed' };
+  }
   return {
-    reply: 'The reply was interrupted before completion. The partial reply above may be incomplete.',
-    status: '⚠️ Interrupted',
+    reply: 'Sorry, an error occurred while processing your message. Please try again later.',
+    status: '⚠️ Failed',
   };
 }
 
@@ -479,6 +491,7 @@ export async function handleMessage(
     ChannelAdapter,
     | 'reply'
     | 'maxMessageLength'
+    | 'nativeStreaming'
     | 'typing'
     | 'getGroupMembers'
     | 'sendStatus'
@@ -676,6 +689,13 @@ export async function handleMessage(
     // a prior sendStatus, to finalize the open stream.
     if (!statusMessageId && !adapter.clearStatus) return;
     debugEventLog(debugEventsEnabled, `[event-debug] gateway status-final textChars=${finalText.length}`);
+    if (adapter.nativeStreaming && adapter.clearStatus) {
+      const currentStatusId = statusMessageId;
+      statusMessageId = undefined;
+      await adapter.clearStatus(msg, currentStatusId ?? '', finalText);
+      statusFinalized = true;
+      return;
+    }
     if (statusMessageId && adapter.updateStatus) {
       await adapter.updateStatus(msg, statusMessageId, finalText);
       statusMessageText = finalText;
@@ -685,7 +705,7 @@ export async function handleMessage(
     if (adapter.clearStatus) {
       const currentStatusId = statusMessageId;
       statusMessageId = undefined;
-      await adapter.clearStatus(msg, currentStatusId ?? '');
+      await adapter.clearStatus(msg, currentStatusId ?? '', finalText);
     }
   };
 
@@ -775,7 +795,7 @@ export async function handleMessage(
     if (!body.trim()) return;
     hasVisibleStatus = true;
     cancelThinkingStatus();
-    if (statusMessageId && adapter.updateStatus && statusMessageText !== '✍️ replying...') {
+    if (statusMessageId && adapter.updateStatus && !adapter.nativeStreaming && statusMessageText !== '✍️ replying...') {
       await adapter.updateStatus(msg, statusMessageId, '✍️ replying...');
       statusMessageText = '✍️ replying...';
     }
@@ -955,17 +975,20 @@ export async function handleMessage(
       }
 
       if (!trimmed && hasError) {
-        await sendChunk('Sorry, an error occurred while processing your message. Please try again later.');
-        fullReply = 'Sorry, an error occurred while processing your message. Please try again later.';
+        // No partial output + error: surface the detailed reply text (no emoji)
+        // through sendChunk so the user sees the real outcome. The emoji status
+        // is delivered separately via finalizeStatusUpdate → clearStatus.
+        fullReply = buildErrorNotice(lastErrorMessage, timeoutSeconds, !!trimmed).reply;
+        if (!adapter.nativeStreaming || (hasError && !/stopped by user/i.test(lastErrorMessage))) {
+          await sendChunk(fullReply);
+        }
       }
 
       let finalStatusText: string | undefined;
-      if (trimmed && hasError) {
-        const notice = buildErrorNotice(lastErrorMessage, timeoutSeconds);
-        await sendChunk(notice.reply);
+      if (hasError) {
+        const notice = buildErrorNotice(lastErrorMessage, timeoutSeconds, !!trimmed);
+        if (trimmed) await sendChunk(notice.reply);
         finalStatusText = notice.status;
-      } else if (hasError) {
-        finalStatusText = '⚠️ Failed';
       }
 
       // Strip media markers before splitTrailingContinue so that the returned
@@ -1027,8 +1050,11 @@ export async function handleMessage(
         return { fullReply: '', hasError, silent: true, sawContinue: false };
       }
 
-      if (!fullReply.trim() && hasError) {
-        fullReply = 'Sorry, an error occurred while processing your message. Please try again later.';
+      if (!trimmedBuf && hasError) {
+        // No partial output + error: surface the detailed reply text (no emoji)
+        // through sendChunk so the user sees the real outcome. The emoji status
+        // is delivered separately via finalizeStatusUpdate → clearStatus.
+        fullReply = buildErrorNotice(lastErrorMessage, timeoutSeconds, !!trimmedBuf).reply;
       }
 
       // Strip media markers before splitTrailingContinue so that the returned
@@ -1037,17 +1063,26 @@ export async function handleMessage(
       const { body, hasContinue } = splitTrailingContinue(mediaStrippedReplyBuf);
       const willRelay = hasContinue && mayRelay && !hasError;
       if (fullReply.trim()) {
-        await sendChunk(fullReply);
-        let finalStatusText: string | undefined;
+        // nativeStreaming adapters (WeCom) deliver the no-output error text via
+        // finalizeStatusUpdate → clearStatus; sendChunk here would duplicate it.
+        // User-initiated /stop: the command handler already sent text; only
+        // finalizeStatusUpdate → clearStatus delivers the ⏹️ Stopped finalText.
+        // Other errors (timeout / engine failure) without output: sendChunk the
+        // detailed reply so the user sees the real cause.
         if (
-          hasError &&
-          fullReply !== 'Sorry, an error occurred while processing your message. Please try again later.'
+          trimmedBuf ||
+          !adapter.nativeStreaming ||
+          (!trimmedBuf && hasError && !/stopped by user/i.test(lastErrorMessage))
         ) {
-          const notice = buildErrorNotice(lastErrorMessage, timeoutSeconds);
-          await sendChunk(notice.reply);
+          await sendChunk(fullReply);
+        }
+        let finalStatusText: string | undefined;
+        if (hasError) {
+          const notice = buildErrorNotice(lastErrorMessage, timeoutSeconds, !!trimmedBuf);
+          if (trimmedBuf) {
+            await sendChunk(notice.reply);
+          }
           finalStatusText = notice.status;
-        } else if (hasError) {
-          finalStatusText = '⚠️ Failed';
         }
         if (!willRelay) await finalizeStatusUpdate(finalStatusText ?? '✅ Done');
         log(verbose, `[${channelType}] replied to ${senderLabel}: "${fullReply.trim().slice(0, 80)}..."`);
@@ -1112,6 +1147,13 @@ export async function handleMessage(
     }
     cancelThinkingStatus();
     if (typingTimer !== undefined) clearInterval(typingTimer);
+    // nativeStreaming adapters (WeCom): the auto-continue typing interval may
+    // have opened a loading stream just before being cleared (e.g. a /stop
+    // landed between ticks). Silently close any leftover stream without
+    // resending the final text (empty finalText = no visible message).
+    if (adapter.nativeStreaming && adapter.clearStatus) {
+      await adapter.clearStatus(msg, '', '').catch(() => {});
+    }
   }
 }
 
@@ -1545,6 +1587,7 @@ export async function startGateway(opts: GatewayOpts): Promise<void> {
           ChannelAdapter,
           | 'reply'
           | 'maxMessageLength'
+          | 'nativeStreaming'
           | 'typing'
           | 'getGroupMembers'
           | 'sendStatus'
@@ -1553,6 +1596,7 @@ export async function startGateway(opts: GatewayOpts): Promise<void> {
           | 'sendMedia'
         > = {
           maxMessageLength: adapter.maxMessageLength,
+          nativeStreaming: adapter.nativeStreaming,
           typing: adapter.typing?.bind(adapter),
           getGroupMembers: adapter.getGroupMembers?.bind(adapter),
           sendStatus: adapter.sendStatus?.bind(adapter),

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -311,8 +311,8 @@ export function buildGroupPrompt(
   peers?: PeerBot[],
   /** When true, inject the turn-end contract so the agent signals unfinished work with [CONTINUE]. */
   injectContinue = false,
-  /** When true (default), inject the media protocol hint so agents know how to send images/files. */
-  mediaHintSupported = true,
+  /** When true, inject the media protocol hint so agents know how to send images/files. */
+  mediaHintSupported = false,
 ): string {
   const parts: string[] = [];
 
@@ -543,11 +543,15 @@ export async function handleMessage(
       if (isStop) {
         // /stop is special: the aborted handler owns the finalText (⏹️ Stopped).
         await adapter.reply(msg, result.text);
-      } else if (adapter.typing && adapter.clearStatus) {
+      } else if (adapter.nativeStreaming) {
+        // nativeStreaming adapters (WeCom) implement a 3-arg clearStatus that
+        // carries the finalText — so slash output can be delivered in-place.
+        // Telegram/Slack use a 2-arg clearStatus that silently swallows text,
+        // so they must fall through to reply() below.
         // executeCommand may have been fast — ensure the loading is visible
         // for at least 200ms before closing with the command output.
         await new Promise<void>((r) => setTimeout(r, 200));
-        await adapter.clearStatus(msg, '', result.text.trim()).catch(() => {});
+        await adapter.clearStatus!(msg, '', result.text.trim()).catch(() => {});
       } else {
         await adapter.reply(msg, result.text);
       }
@@ -713,7 +717,7 @@ export async function handleMessage(
         // handler's "Stopped the current task." land first, then send the
         // ⏹️ Stopped finalText as a separate message.
         await adapter.clearStatus(msg, statusMessageId ?? '', '').catch(() => {});
-        await new Promise(r => setTimeout(r, 200));
+        await new Promise((r) => setTimeout(r, 200));
         await adapter.reply(msg, finalText).catch(() => {});
       } else {
         // Normal completion / timeout / generic failure: keep the original
@@ -1026,7 +1030,11 @@ export async function handleMessage(
       const { body, hasContinue } = splitTrailingContinue(mediaStrippedReply);
       const willRelay = hasContinue && mayRelay && !hasError;
       if (fullReply.trim()) {
-        if (!willRelay) await finalizeStatusUpdate(finalStatusText ?? '✅ Done', lastErrorMessage === 'Agent invocation stopped by user');
+        if (!willRelay)
+          await finalizeStatusUpdate(
+            finalStatusText ?? '✅ Done',
+            lastErrorMessage === 'Agent invocation stopped by user',
+          );
         log(verbose, `[${channelType}] replied to ${senderLabel}: "${fullReply.trim().slice(0, 80)}..." (streaming)`);
         trackMetrics({ responsePreview: body.trim().slice(0, 120) });
       }
@@ -1113,7 +1121,11 @@ export async function handleMessage(
           }
           finalStatusText = notice.status;
         }
-        if (!willRelay) await finalizeStatusUpdate(finalStatusText ?? '✅ Done', lastErrorMessage === 'Agent invocation stopped by user');
+        if (!willRelay)
+          await finalizeStatusUpdate(
+            finalStatusText ?? '✅ Done',
+            lastErrorMessage === 'Agent invocation stopped by user',
+          );
         log(verbose, `[${channelType}] replied to ${senderLabel}: "${fullReply.trim().slice(0, 80)}..."`);
         trackMetrics({ responsePreview: body.trim().slice(0, 120) });
       }

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -1,5 +1,5 @@
-import { mkdir, readFile as readFileAsync } from 'node:fs/promises';
-import { dirname, join, resolve } from 'node:path';
+import { mkdir, readFile as readFileAsync, realpath, stat } from 'node:fs/promises';
+import { basename, dirname, isAbsolute, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   buildConversationKey,
@@ -120,12 +120,79 @@ export const AUTO_CONTINUE_PROMPT =
   `[System: Auto-continue. Your previous reply ended with ${CONTINUE_SENTINEL}. Continue working on the task. ` +
   `End with ${CONTINUE_SENTINEL} again if it is still unfinished.]`;
 
+/** Prompt hint reminding agents how to send images/files via markers. */
+export const MEDIA_PROTOCOL_HINT =
+  '[System: When the user asks you to send/generate an image or file, save it to the workspace `temp_file/` dir and output ' +
+  '[SEND_IMAGE: temp_file/<file>] or [SEND_FILE: temp_file/<file>] on its own standalone line — the gateway sends it automatically. ' +
+  'Do NOT use the message-push / Send API for this (it only supports text).]';
+
 const TRAILING_CONTINUE_RE = /(?:^|\n)\s*\[CONTINUE\]\s*$/;
 
 /** Split a trailing [CONTINUE] sentinel line off a reply. */
 export function splitTrailingContinue(text: string): { body: string; hasContinue: boolean } {
   if (!TRAILING_CONTINUE_RE.test(text)) return { body: text, hasContinue: false };
   return { body: text.replace(TRAILING_CONTINUE_RE, '').trimEnd(), hasContinue: true };
+}
+
+// —— Media marker protocol parsing ————————————————————————————————————————————
+// Agents output standalone lines [SEND_IMAGE: <path>] or [SEND_FILE: <path>]
+// in their reply text. The gateway extracts these, resolves the file path against
+// the assistant directory, reads the file bytes, and calls adapter.sendMedia.
+
+/**
+ * Matches a standalone [SEND_IMAGE: <path>] / [SEND_FILE: <path>] line.
+ * NOTE: carries the `g` flag — when using .test()/.exec() directly, reset lastIndex
+ * (e.g. new RegExp(source, flags)) or prefer extractMediaMarkers().
+ */
+export const MEDIA_MARKER_RE = /^\[SEND_(IMAGE|FILE):\s*(\S.*?)\]\s*$/gim;
+
+/**
+ * Extract media markers from agent reply text.
+ * Returns the stripped body and the list of parsed markers.
+ * Pure function — no side effects, safe to call idempotently.
+ */
+export function extractMediaMarkers(text: string): {
+  body: string;
+  markers: Array<{ kind: 'image' | 'file'; path: string }>;
+} {
+  const markers: Array<{ kind: 'image' | 'file'; path: string }> = [];
+  const body = text.replace(MEDIA_MARKER_RE, (_match, kind: string, rawPath: string) => {
+    markers.push({ kind: kind.toLowerCase() as 'image' | 'file', path: rawPath.trim() });
+    return '';
+  });
+  return { body, markers };
+}
+
+/**
+ * Resolve a file path from a media marker against the allowed root.
+ * Returns the resolved absolute path or `null` if it escapes the allowed root.
+ *
+ * - Only the assistant workspace directory (`baseDir`) is allowed.
+ * - Relative paths are resolved against `baseDir`.
+ * - Absolute paths are checked to ensure they stay inside `baseDir`.
+ * - Symlinks are resolved via `realpath` to prevent symlink escapes.
+ *   If the file does not exist, the prefix check alone is sufficient.
+ */
+export async function resolveOutboundPath(baseDir: string, rawPath: string): Promise<string | null> {
+  const resolvedBase = resolve(baseDir);
+
+  // —— Single allowed root: the assistant workspace ——
+  async function tryOne(candidate: string): Promise<string | null> {
+    if (!candidate.startsWith(resolvedBase + sep) && candidate !== resolvedBase) return null;
+
+    const realRoot = await realpath(resolvedBase).catch(() => resolvedBase);
+    try {
+      const real = await realpath(candidate);
+      return real.startsWith(realRoot + sep) || real === realRoot ? real : null;
+    } catch {
+      // File doesn't exist yet — return candidate as fallback
+      return candidate;
+    }
+  }
+
+  // —— Resolve the candidate path ——
+  const candidate = isAbsolute(rawPath) ? resolve(rawPath) : resolve(resolvedBase, rawPath);
+  return tryOne(candidate);
 }
 
 /** Monotonic inbound counter per session key — a newer message interrupts pending auto-continue relays. */
@@ -238,6 +305,10 @@ export function buildGroupPrompt(
   if (injectContinue) {
     parts.push(TURN_END_CONTRACT);
   }
+
+  // Always inject media protocol hint into group prompts so agents remember
+  // how to send images/files even when the prompt is large and dilutes skill guidance.
+  parts.push(MEDIA_PROTOCOL_HINT);
 
   if (injectPass) {
     const base =
@@ -401,13 +472,20 @@ export async function handleMessage(
   >,
   adapter: Pick<
     ChannelAdapter,
-    'reply' | 'maxMessageLength' | 'typing' | 'getGroupMembers' | 'sendStatus' | 'updateStatus' | 'clearStatus'
+    | 'reply'
+    | 'maxMessageLength'
+    | 'typing'
+    | 'getGroupMembers'
+    | 'sendStatus'
+    | 'updateStatus'
+    | 'clearStatus'
+    | 'sendMedia'
   >,
   channelType: string,
   verbose: boolean,
   dir: string,
   metrics?: GatewayMetrics,
-  cronCtx?: { taskStore: TaskStore; scheduler: Scheduler; runTask: (id: string) => Promise<string> },
+  cronCtx?: { taskStore: TaskStore; scheduler: Scheduler; runTask?: (id: string) => Promise<string> },
   /** Fleet peers for multi-bot awareness. */
   peers?: PeerBot[],
 ): Promise<void> {
@@ -586,9 +664,12 @@ export async function handleMessage(
 
   const finalizeStatusUpdate = async (finalText = '✅ Done'): Promise<void> => {
     cancelThinkingStatus();
-    if (!statusMessageId) return;
+    // Skip only when neither a status message exists nor the adapter has clearStatus.
+    // Adapters that support streaming (e.g. WeCom) need clearStatus called even without
+    // a prior sendStatus, to finalize the open stream.
+    if (!statusMessageId && !adapter.clearStatus) return;
     debugEventLog(debugEventsEnabled, `[event-debug] gateway status-final textChars=${finalText.length}`);
-    if (adapter.updateStatus) {
+    if (statusMessageId && adapter.updateStatus) {
       await adapter.updateStatus(msg, statusMessageId, finalText);
       statusMessageText = finalText;
       statusFinalized = true;
@@ -597,7 +678,7 @@ export async function handleMessage(
     if (adapter.clearStatus) {
       const currentStatusId = statusMessageId;
       statusMessageId = undefined;
-      await adapter.clearStatus(msg, currentStatusId);
+      await adapter.clearStatus(msg, currentStatusId ?? '');
     }
   };
 
@@ -607,14 +688,82 @@ export async function handleMessage(
     }, 1500);
   }
 
+  // Pre-declare so processMedia can reference sendChunk for error notices.
+  let sendChunk: (rawText: string) => Promise<void>;
+
+  // Helper: extract and process outbound media markers from text.
+  // Returns the stripped body. Error notices are sent via sendChunk.
+  const processMedia = async (rawText: string): Promise<string> => {
+    const { body, markers } = extractMediaMarkers(rawText);
+    if (markers.length === 0) return body;
+
+    for (const marker of markers) {
+      try {
+        const resolved = await resolveOutboundPath(dir, marker.path);
+        if (!resolved) {
+          const label = marker.kind === 'image' ? '图片' : '文件';
+          await sendChunk(`⚠️ 无法发送${label} ${marker.path}：路径超出助手目录范围`);
+          continue;
+        }
+
+        const maxSize = marker.kind === 'image' ? 10 * 1024 * 1024 : 20 * 1024 * 1024;
+        let fileStat;
+        try {
+          fileStat = await stat(resolved);
+        } catch {
+          const label = marker.kind === 'image' ? '图片' : '文件';
+          await sendChunk(`⚠️ 无法发送${label} ${marker.path}：文件不存在或无法读取`);
+          continue;
+        }
+
+        if (fileStat.size > maxSize) {
+          const label = marker.kind === 'image' ? '图片' : '文件';
+          const maxLabel = marker.kind === 'image' ? '10MB' : '20MB';
+          await sendChunk(`⚠️ 无法发送${label} ${marker.path}：文件大小超过${maxLabel}`);
+          continue;
+        }
+
+        if (!adapter.sendMedia) {
+          log(verbose, `[${channelType}] adapter lacks sendMedia, skipping ${marker.kind} ${marker.path}`);
+          continue;
+        }
+
+        let data: Buffer;
+        try {
+          data = await readFileAsync(resolved);
+        } catch {
+          const label = marker.kind === 'image' ? '图片' : '文件';
+          await sendChunk(`⚠️ 无法发送${label} ${marker.path}：文件读取失败`);
+          continue;
+        }
+
+        await adapter.sendMedia(msg, {
+          kind: marker.kind,
+          data,
+          fileName: basename(resolved),
+        });
+      } catch (e) {
+        const reason = e instanceof Error ? e.message : String(e);
+        const label = marker.kind === 'image' ? '图片' : '文件';
+        log(verbose, `[${channelType}] media processing failed for ${marker.path}: ${reason}`);
+        await sendChunk(`⚠️ 无法发送${label} ${marker.path}：${reason}`);
+      }
+    }
+
+    return body;
+  };
+
   // Helper: send a text chunk to the IM channel (handles splitMessage + mentions).
-  const sendChunk = async (rawText: string): Promise<void> => {
+  sendChunk = async (rawText: string): Promise<void> => {
+    // Extract and process media markers before anything else (idempotent).
+    const text = await processMedia(rawText);
+
     // Safety net: never leak the [CONTINUE] auto-continue sentinel to IM
-    const { body: text, hasContinue } = splitTrailingContinue(rawText);
+    const { body, hasContinue } = splitTrailingContinue(text);
     if (hasContinue) {
       log(verbose, `[${channelType}] sendChunk stripped trailing ${CONTINUE_SENTINEL} sentinel`);
     }
-    if (!text.trim()) return;
+    if (!body.trim()) return;
     hasVisibleStatus = true;
     cancelThinkingStatus();
     if (statusMessageId && adapter.updateStatus && statusMessageText !== '✍️ replying...') {
@@ -622,21 +771,21 @@ export async function handleMessage(
       statusMessageText = '✍️ replying...';
     }
     // Final safety net: never send [PASS]/[SKIP] sentinel values to IM
-    const sentinel = text.trim();
+    const sentinel = body.trim();
     if (sentinel === '[PASS]' || sentinel === '[SKIP]') {
       log(verbose, `[${channelType}] sendChunk blocked sentinel: ${sentinel}`);
       return;
     }
-    const chunks = splitMessage(text.trim(), maxLen);
+    const chunks = splitMessage(body.trim(), maxLen);
     debugEventLog(
       debugEventsEnabled,
-      `[event-debug] gateway reply totalChars=${text.trim().length} chunks=${chunks.length} chatType=${msg.chatType}`,
+      `[event-debug] gateway reply totalChars=${body.trim().length} chunks=${chunks.length} chatType=${msg.chatType}`,
     );
     let mentions: MentionTarget[] = [];
     if (msg.chatType === 'group' && adapter.getGroupMembers) {
       try {
         const memberCache = await adapter.getGroupMembers(msg.chatId);
-        mentions = parseMentions(text.trim(), memberCache).mentions;
+        mentions = parseMentions(body.trim(), memberCache).mentions;
       } catch {
         /* best effort */
       }
@@ -810,7 +959,10 @@ export async function handleMessage(
         finalStatusText = '⚠️ Failed';
       }
 
-      const { body, hasContinue } = splitTrailingContinue(fullReply);
+      // Strip media markers before splitTrailingContinue so that the returned
+      // fullReply (which feeds group history + metrics) never contains marker lines.
+      const mediaStrippedReply = extractMediaMarkers(fullReply).body;
+      const { body, hasContinue } = splitTrailingContinue(mediaStrippedReply);
       const willRelay = hasContinue && mayRelay && !hasError;
       if (fullReply.trim()) {
         if (!willRelay) await finalizeStatusUpdate(finalStatusText ?? '✅ Done');
@@ -870,7 +1022,10 @@ export async function handleMessage(
         fullReply = 'Sorry, an error occurred while processing your message. Please try again later.';
       }
 
-      const { body, hasContinue } = splitTrailingContinue(fullReply);
+      // Strip media markers before splitTrailingContinue so that the returned
+      // fullReply (which feeds group history + metrics) never contains marker lines.
+      const mediaStrippedReplyBuf = extractMediaMarkers(fullReply).body;
+      const { body, hasContinue } = splitTrailingContinue(mediaStrippedReplyBuf);
       const willRelay = hasContinue && mayRelay && !hasError;
       if (fullReply.trim()) {
         await sendChunk(fullReply);
@@ -1105,6 +1260,11 @@ export async function startGateway(opts: GatewayOpts): Promise<void> {
   const dir = resolve(opts.dir || '.');
   setPeerBase(dir);
 
+  // temp_file/ dir for agent-generated files to send (created if missing)
+  mkdir(join(dir, 'temp_file'), { recursive: true }).catch((e) => {
+    console.warn('[gateway] Failed to create temp_file/ dir:', e instanceof Error ? e.message : String(e));
+  });
+
   const config: GolemConfig = await loadConfig(dir);
   const verbose = opts.verbose ?? false;
 
@@ -1276,7 +1436,7 @@ export async function startGateway(opts: GatewayOpts): Promise<void> {
               verbose,
               dir,
               metrics,
-              coordinator ? { taskStore, scheduler, runTask: (id) => coordinator!.runTask(id) } : undefined,
+              { taskStore, scheduler, runTask: coordinator ? (id) => coordinator!.runTask(id) : undefined },
               fleetPeers,
             ),
           );
@@ -1293,6 +1453,15 @@ export async function startGateway(opts: GatewayOpts): Promise<void> {
           if (gc.groupPolicy !== 'mention-only') {
             console.warn(
               `   ⚠️  DingTalk groupPolicy "${gc.groupPolicy}" will behave like "mention-only" — ` +
+                `the platform only delivers @mention messages to bots.`,
+            );
+          }
+        }
+        if (type === 'wecom') {
+          const gc = resolveGroupChatConfig(config);
+          if (gc.groupPolicy !== 'mention-only') {
+            console.warn(
+              `   ⚠️  WeCom groupPolicy "${gc.groupPolicy}" will behave like "mention-only" — ` +
                 `the platform only delivers @mention messages to bots.`,
             );
           }
@@ -1365,7 +1534,14 @@ export async function startGateway(opts: GatewayOpts): Promise<void> {
         // Wrap adapter to fallback to send() when reply() throws.
         const wrappedAdapter: Pick<
           ChannelAdapter,
-          'reply' | 'maxMessageLength' | 'typing' | 'getGroupMembers' | 'sendStatus' | 'updateStatus' | 'clearStatus'
+          | 'reply'
+          | 'maxMessageLength'
+          | 'typing'
+          | 'getGroupMembers'
+          | 'sendStatus'
+          | 'updateStatus'
+          | 'clearStatus'
+          | 'sendMedia'
         > = {
           maxMessageLength: adapter.maxMessageLength,
           typing: adapter.typing?.bind(adapter),
@@ -1373,6 +1549,7 @@ export async function startGateway(opts: GatewayOpts): Promise<void> {
           sendStatus: adapter.sendStatus?.bind(adapter),
           updateStatus: adapter.updateStatus?.bind(adapter),
           clearStatus: adapter.clearStatus?.bind(adapter),
+          sendMedia: adapter.sendMedia?.bind(adapter),
           reply: async (m, text, opts) => {
             try {
               await adapter.reply(m, text, opts);
@@ -1396,7 +1573,7 @@ export async function startGateway(opts: GatewayOpts): Promise<void> {
           verbose,
           dir,
           metrics,
-          coordinator ? { taskStore, scheduler, runTask: (id) => coordinator!.runTask(id) } : undefined,
+          { taskStore, scheduler, runTask: coordinator ? (id) => coordinator!.runTask(id) : undefined },
           fleetPeers,
         );
 


### PR DESCRIPTION
## 概要

企微（WeCom）通道的功能升级：重构状态消息流式管道、支持图片/文件发送协议、slash 命令流式输出，并修复多个错误处理与加载体验问题。

## 核心功能

### 1. 流式状态管道（nativeStreaming）

- `WecomAdapter` 标记为 `nativeStreaming`，gateway 将最终状态（`✅ Done` / `⚠️ Failed` / `⏹️ Stopped` / `⚠️ Timed out`）通过 `clearStatus(finalText)` 忠实传递
- 修复 `aibot_send_msg` 拒绝 `msgtype:text`（errcode 40008）的问题——无流时改用 `replyStream` 经 frame 回复
- `updateStatus` 改为 no-op（native loading UI 已足够）

### 2. 图片/文件发送协议（send-media）

- `MEDIA_PROTOCOL_HINT` 仅在 adapter 支持 `sendMedia` 时注入（群聊 + DM 一致）
- agent 输出 `[SEND_IMAGE: path]` / `[SEND_FILE: path]` marker → gateway 解析 → `adapter.sendMedia` 发送
- 不支持 `sendMedia` 的渠道：用户可见降级提示（`⚠️ 当前渠道不支持发送图片`）
- `temp_file/` 作为运行时暂存目录（已加入 `.gitignore`）

### 3. Slash 命令流式输出

- `/model`、`/help`、`/reset` 等命令现在打开 native loading 流 → 命令执行 → 流内显示结果（与普通对话体验一致）
- `typing()` 先开流再发 sendTyping，loading 立即出现

### 4. 错误处理与 finalText 修复

- `buildErrorNotice` 结构化：reply（无 emoji 详情）与 status（emoji 简短态）分离
- 通用错误吐出真实 agent 错误，空错误回退 `Sorry...`；无部分输出时不加 "partial reply above" 后缀
- `/stop`：命令 handler 不再发 finalText（避免双发），由被取消 handler 独立发 `⏹️ Stopped`（顺序：`Stopped the current task.` → `⏹️ Stopped`）
- 修复 typing interval 竞态导致的残留空流

### 5. opencode Windows 兼容

- `findOpenCodeBin` 优先使用 npm 全局安装的 `.exe`（避免 PowerShell shim 的 stdin 编码问题）

## 变更统计

- **17 个文件变更，+2,543 / -77**
- 核心：`wecom.ts`（+168）、`gateway.ts`（+351）、`channel.ts`（+23）
- 测试：`gateway-media.test.ts`（+793）、`wecom.test.ts`（+599）、`gateway.test.ts`（+445）

## 测试

- `wecom.test.ts`：流式状态、clearStatus finalText、typing、sendMedia
- `gateway-media.test.ts`：media marker 协议、路径安全、降级提示
- `gateway.test.ts` / `gateway-integration.test.ts`：slash 流式、/stop、空流清理
- `opencode-stdin.test.ts`：Windows .exe shim
- `pnpm run build` 通过