### PR TITLE
fix(index): align listModels model resolution with getStatus/doChat

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { AgentEngine, InvokeOpts, StreamEvent } from '../engine.js';
+import type { AgentEngine, InvokeOpts, ListModelsOpts, StreamEvent } from '../engine.js';
 
 // ── Mock engines ────────────────────────────────────────
 
@@ -1180,5 +1180,53 @@ describe('getStatus model resolution', () => {
     const assistant = createAssistant({ dir });
     const status = await assistant.getStatus();
     expect(status.model).toBeUndefined();
+  });
+});
+
+describe('listModels model resolution', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'golem-test-listmodels-'));
+    await mkdir(join(dir, 'skills', 'general'), { recursive: true });
+    await writeFile(
+      join(dir, 'skills', 'general', 'SKILL.md'),
+      '---\nname: general\ndescription: General assistant\n---\n# General\n',
+    );
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it('passes the effective model (provider.model) to engine.listModels', async () => {
+    // Regression: listModels() used modelOverride || config.model, ignoring
+    // provider precedence. It must pass the same effective model that
+    // doChat()/getStatus() resolve, so the hint matches actual invocation.
+    await writeFile(
+      join(dir, 'golem.yaml'),
+      [
+        'name: test-bot',
+        'engine: opencode',
+        'model: xyzq/deepseek-v4-flash',
+        'provider:',
+        '  model: opencode-go/deepseek-v4-flash',
+      ].join('\n'),
+    );
+
+    let capturedModel: string | undefined;
+    mockedCreateEngine.mockReturnValue({
+      async *invoke(): AsyncIterable<StreamEvent> {},
+      async listModels(opts: ListModelsOpts) {
+        capturedModel = opts.model;
+        return ['model-a', 'model-b'];
+      },
+    });
+
+    const assistant = createAssistant({ dir });
+    await assistant.listModels();
+
+    expect(capturedModel).toBe('opencode-go/deepseek-v4-flash');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -684,7 +684,11 @@ export function createAssistant(opts: CreateAssistantOpts): Assistant {
     async listModels(): Promise<string[]> {
       const config = await loadConfig(dir);
       const engineType = engineOverride || config.engine;
-      const model = modelOverride || config.model;
+      const baseProvider = providerOverride || config.provider;
+      const provider = usingFallback && baseProvider?.fallback ? baseProvider.fallback : baseProvider;
+      // Align with doChat()/getStatus() so the model hint passed to
+      // engine.listModels matches the one actually used for invocation.
+      const model = provider?.models?.[engineType] || modelOverride || provider?.model || config.model;
       const engine = createEngine(engineType);
       if (!engine.listModels) return [];
       return engine.listModels({ apiKey, model });


### PR DESCRIPTION
## 概要

`index.ts` 的 `listModels()` 仍用旧的 `modelOverride || config.model` 解析模型，而 `getStatus()` 和 `doChat()` 已统一为完整的优先级解析（`provider.models[engine] > modelOverride > provider.model > config.model`）。本 PR 将 `listModels()` 对齐到同一解析逻辑。

## 背景

这是 PR #51 review 中提到的非阻塞项：

> index.ts 的 listModels()（约 680 行）仍在用旧的 modelOverride || config.model 解析。它只是给 engine.listModels 传 hint，影响很小，但如果顺手可以一并对齐。

## 改动

`src/index.ts` `listModels()`：

```typescript
// 修复前
const model = modelOverride || config.model;

// 修复后（与 doChat/getStatus 完全一致）
const baseProvider = providerOverride || config.provider;
const provider = usingFallback && baseProvider?.fallback ? baseProvider.fallback : baseProvider;
const model = provider?.models?.[engineType] || modelOverride || provider?.model || config.model;
```

## 功能影响
对 opencode 引擎，model hint 的 provider 前缀决定 /model list 走哪条列模型路径：
- provider === 'openrouter' → 走 OpenRouter 公开 API
- 其他 → 走 CLI fallback
修复前，仅配置 provider.model（未配置顶层 model）时，hint 为 undefined，导致错误走 CLI fallback；修复后能正确识别 provider 前缀。
其余引擎（cursor/claude-code/codex）的 listModels 不消费 model 参数，无影响。
## 测试
新增 listModels model resolution 单元测试，断言 provider.model 被正确传给 engine.listModels。