### PR TITLE
fix(codex): place exec flags before resume subcommand

### DIFF
--- a/src/__tests__/engine.test.ts
+++ b/src/__tests__/engine.test.ts
@@ -1650,7 +1650,6 @@ describe('buildCodexExecArgs', () => {
 
     expect(args).toEqual([
       'exec',
-      'resume',
       '--json',
       '--dangerously-bypass-approvals-and-sandbox',
       '--skip-git-repo-check',
@@ -1660,6 +1659,7 @@ describe('buildCodexExecArgs', () => {
       'model_provider="minimax"',
       '-c',
       'model_providers.minimax.wire_api="responses"',
+      'resume',
       '--model',
       'gpt-5.4',
       'thread_123',

--- a/src/engines/codex.ts
+++ b/src/engines/codex.ts
@@ -46,7 +46,7 @@ export function buildCodexExecArgs(
   const imageFlags = (opts.imagePaths ?? []).flatMap((path) => ['--image', path]);
   const trailingArgs = [prompt, ...imageFlags];
   return opts.sessionId
-    ? [...globalFlags, 'exec', 'resume', ...sharedFlags, ...modelFlag, opts.sessionId, ...trailingArgs]
+    ? [...globalFlags, 'exec', ...sharedFlags, 'resume', ...modelFlag, opts.sessionId, ...trailingArgs]
     : [...globalFlags, 'exec', ...sharedFlags, ...modelFlag, ...trailingArgs];
 }
 


### PR DESCRIPTION
## Summary

Fix Codex resume invocations so flags that belong to `codex exec` are placed before the `resume` subcommand.

GolemBot currently builds resume commands like:

`codex ... exec resume --sandbox workspace-write ...`

With current Codex CLI versions, `resume` does not accept `--sandbox` (and other exec-level flags such as `--profile` / `--add-dir`), causing resumed sessions to fail with errors such as:

`error: unexpected argument '--sandbox' found`

This changes the argument order to:

`codex ... exec --sandbox workspace-write ... resume ...`

and updates the existing `buildCodexExecArgs` regression test accordingly.

## Validation

- `pnpm exec vitest run src/__tests__/engine.test.ts -t "buildCodexExecArgs"` — 6 tests passed
- `pnpm exec biome check src/engines/codex.ts src/__tests__/engine.test.ts` — passed
- `pnpm run build` — passed
- Verified in a real resumed Codex session: consecutive Telegram turns successfully executed shell commands without the previous `--sandbox` error.