### PR TITLE
fix(codex): discover models from Codex local cache

### DIFF
--- a/src/__tests__/engine.test.ts
+++ b/src/__tests__/engine.test.ts
@@ -1957,3 +1957,79 @@ describe('ensureOpenCodeConfig mcp', () => {
     expect(stat2.mtimeMs).toBe(stat1.mtimeMs);
   });
 });
+
+describe('CodexEngine.listModels local model cache', () => {
+  let codexHome: string;
+  let previousCodexHome: string | undefined;
+  let previousCodexApiKey: string | undefined;
+  let previousOpenAiApiKey: string | undefined;
+
+  beforeEach(async () => {
+    codexHome = await mkdtemp(join(tmpdir(), 'golem-codex-models-'));
+
+    previousCodexHome = process.env.CODEX_HOME;
+    previousCodexApiKey = process.env.CODEX_API_KEY;
+    previousOpenAiApiKey = process.env.OPENAI_API_KEY;
+
+    process.env.CODEX_HOME = codexHome;
+    delete process.env.CODEX_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(async () => {
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+
+    if (previousCodexApiKey === undefined) delete process.env.CODEX_API_KEY;
+    else process.env.CODEX_API_KEY = previousCodexApiKey;
+
+    if (previousOpenAiApiKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = previousOpenAiApiKey;
+
+    await rm(codexHome, { recursive: true, force: true });
+  });
+
+  it('reads listable models from CODEX_HOME and orders them by priority', async () => {
+    await writeFile(
+      join(codexHome, 'models_cache.json'),
+      JSON.stringify({
+        models: [
+          { slug: 'model-low', visibility: 'list', priority: 20 },
+          { slug: 'model-hidden', visibility: 'hidden', priority: 1 },
+          { slug: 'model-high', visibility: 'list', priority: 5 },
+          { visibility: 'list', priority: 0 },
+        ],
+      }),
+    );
+
+    const engine = new CodexEngine();
+
+    await expect(engine.listModels({})).resolves.toEqual(['model-high', 'model-low']);
+  });
+
+  it('falls back to the static model list when the cache is missing', async () => {
+    const engine = new CodexEngine();
+
+    await expect(engine.listModels({})).resolves.toEqual([
+      'gpt-5.4',
+      'gpt-5.3-codex',
+      'gpt-5.2-codex',
+      'gpt-5.1-codex-max',
+      'codex-mini-latest',
+    ]);
+  });
+
+  it('falls back to the static model list when the cache is malformed', async () => {
+    await writeFile(join(codexHome, 'models_cache.json'), '{invalid-json');
+
+    const engine = new CodexEngine();
+
+    await expect(engine.listModels({})).resolves.toEqual([
+      'gpt-5.4',
+      'gpt-5.3-codex',
+      'gpt-5.2-codex',
+      'gpt-5.1-codex-max',
+      'codex-mini-latest',
+    ]);
+  });
+});

--- a/src/engines/codex.ts
+++ b/src/engines/codex.ts
@@ -1,4 +1,5 @@
-import { lstat, mkdir, readdir, symlink, unlink } from 'node:fs/promises';
+import { lstat, mkdir, readdir, readFile, symlink, unlink } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import { basename, join, resolve } from 'node:path';
 import { assessCodexProviderCompatibility } from '../codex-provider-compat.js';
 import { debugEventLog, isDebugEventsEnabled, summarizeJsonEventLine } from '../debug-events.js';
@@ -339,6 +340,28 @@ export class CodexEngine implements AgentEngine {
   }
 
   async listModels(opts: ListModelsOpts): Promise<string[]> {
+    try {
+      const codexHome = process.env.CODEX_HOME || join(homedir(), '.codex');
+      const cachePath = join(codexHome, 'models_cache.json');
+      const raw = await readFile(cachePath, 'utf8');
+      const data = JSON.parse(raw) as {
+        models?: Array<{
+          slug?: string;
+          visibility?: string;
+          priority?: number;
+        }>;
+      };
+
+      const models = (data.models ?? [])
+        .filter((m) => m.slug && m.visibility === 'list')
+        .sort((a, b) => (a.priority ?? Number.MAX_SAFE_INTEGER) - (b.priority ?? Number.MAX_SAFE_INTEGER))
+        .map((m) => m.slug as string);
+
+      if (models.length > 0) return models;
+    } catch {
+      /* fallback below */
+    }
+
     const apiKey = opts.apiKey || process.env.CODEX_API_KEY || process.env.OPENAI_API_KEY;
     if (apiKey) {
       try {


### PR DESCRIPTION
## Summary

Prefer Codex's local model cache when listing available models.

Codex CLI maintains the user's model catalog in `${CODEX_HOME:-~/.codex}/models_cache.json`. When that cache is available, `CodexEngine.listModels()` now:

- reads `models_cache.json`
- keeps models with `visibility: "list"`
- orders them by `priority`
- returns their `slug` values

If the cache is missing, malformed, or contains no listable models, the existing API/static fallbacks are preserved.

This is useful for Codex CLI setups where the locally available model catalog may be newer or more accurate than GolemBot's static fallback list.

## Tests

Added coverage for:

- reading and priority-ordering listable models from `CODEX_HOME`
- falling back when the cache is missing
- falling back when the cache is malformed

## Validation

- `pnpm exec vitest run src/__tests__/engine.test.ts` — 142 tests passed
- `pnpm exec biome check src/engines/codex.ts src/__tests__/engine.test.ts` — passed
- `pnpm run build` — passed

Complementary to #54: that PR aligns the model hint passed into engines; this PR improves how the Codex engine itself discovers available models.