### PR TITLE
fix(discord): avoid blocking group replies on member fetch

### DIFF
--- a/src/__tests__/gateway-integration.test.ts
+++ b/src/__tests__/gateway-integration.test.ts
@@ -1130,14 +1130,19 @@ describe('handleMessage — full gateway pipeline', () => {
       expect(adapter.replies[0].options).toBeUndefined();
     });
 
-    it('passes no mentions when reply text has no @patterns matching members', async () => {
+    it('does not fetch group members when reply text has no @ pattern', async () => {
+      let called = false;
       const assistant = makeMockAssistant('sure, I will handle it');
       const adapter = makeMockAdapter();
-      adapter.getGroupMembers = async () => new Map([['alice', 'ou_alice']]);
+      adapter.getGroupMembers = async () => {
+        called = true;
+        return new Map([['alice', 'ou_alice']]);
+      };
       const msg = makeGroupMsg({ text: '@golem do it' });
       const config = makeConfig({ groupChat: { groupPolicy: 'mention-only' } } as any);
       await handleMessage(msg, config, assistant, adapter, 'slack', false, dir);
 
+      expect(called).toBe(false);
       expect(adapter.replies.length).toBeGreaterThanOrEqual(1);
       expect(adapter.replies[0].options).toBeUndefined();
     });

--- a/src/__tests__/gateway.test.ts
+++ b/src/__tests__/gateway.test.ts
@@ -704,6 +704,81 @@ describe('DiscordAdapter', () => {
     const adapter = new (DiscordAdapter as any)({ botToken: 'fake-token' });
     await expect(adapter.stop()).resolves.toBeUndefined();
   });
+
+  it('replies with cached mentions when the full member fetch hangs', async () => {
+    vi.useFakeTimers();
+    const dir = await mkdtemp(join(tmpdir(), 'golem-discord-members-'));
+    try {
+      const { DiscordAdapter } = await import('../channels/discord.js');
+      const adapter = new (DiscordAdapter as any)({ botToken: 'fake-token' });
+      const replies: string[] = [];
+      let memberFetchStarted = false;
+      const cachedMembers = new Map([
+        [
+          'user-1',
+          {
+            displayName: 'Alice',
+            user: { bot: false, username: 'alice' },
+          },
+        ],
+      ]);
+      adapter.client = {
+        channels: {
+          fetch: async () => ({
+            guild: {
+              members: {
+                cache: cachedMembers,
+                fetch: async () => {
+                  memberFetchStarted = true;
+                  return new Promise(() => {});
+                },
+              },
+            },
+          }),
+        },
+      };
+      const assistant = {
+        async *chat() {
+          yield { type: 'text' as const, content: 'Hello @Alice' };
+          yield { type: 'done' as const, durationMs: 1 };
+        },
+      };
+      const msg: ChannelMessage = {
+        channelType: 'discord',
+        senderId: 'user-2',
+        senderName: 'Bob',
+        chatId: 'channel-1',
+        chatType: 'group',
+        text: 'hello',
+        mentioned: true,
+        raw: {
+          async reply(payload: { content: string }) {
+            replies.push(payload.content);
+          },
+        },
+      };
+
+      const task = handleMessage(
+        msg,
+        { name: 'GolemBot', engine: 'cursor' } as any,
+        assistant as any,
+        adapter,
+        'discord',
+        false,
+        dir,
+      );
+
+      await vi.waitFor(() => expect(memberFetchStarted).toBe(true));
+      await vi.advanceTimersByTimeAsync(2_000);
+      await task;
+
+      expect(replies).toEqual(['Hello <@user-1>']);
+    } finally {
+      vi.useRealTimers();
+      await rm(dir, { recursive: true, force: true });
+      clearGroupChatState('discord:channel-1');
+    }
+  });
 });
 
 describe('processMedia - degradation notice for non-sendMedia channels', () => {

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -6,6 +6,7 @@ export class DiscordAdapter implements ChannelAdapter {
   readonly name = 'discord';
   /** Discord's per-message character limit for regular messages. */
   readonly maxMessageLength = 2000;
+  private static readonly MEMBER_FETCH_TIMEOUT_MS = 2_000;
 
   private config: DiscordChannelConfig;
   private client: any = null;
@@ -108,7 +109,20 @@ export class DiscordAdapter implements ChannelAdapter {
     try {
       const channel = await this.client.channels.fetch(chatId);
       if (!channel?.guild) return new Map();
-      const guildMembers = await channel.guild.members.fetch();
+      const memberManager = channel.guild.members;
+      const cachedMembers = memberManager.cache ?? new Map();
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      let guildMembers;
+      try {
+        guildMembers = await Promise.race([
+          memberManager.fetch().catch(() => cachedMembers),
+          new Promise((resolve) => {
+            timeout = setTimeout(() => resolve(cachedMembers), DiscordAdapter.MEMBER_FETCH_TIMEOUT_MS);
+          }),
+        ]);
+      } finally {
+        if (timeout) clearTimeout(timeout);
+      }
       const members = new Map<string, string>();
       for (const [id, member] of guildMembers) {
         if (member.user.bot) continue;

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -844,7 +844,8 @@ export async function handleMessage(
       `[event-debug] gateway reply totalChars=${body.trim().length} chunks=${chunks.length} chatType=${msg.chatType}`,
     );
     let mentions: MentionTarget[] = [];
-    if (msg.chatType === 'group' && adapter.getGroupMembers) {
+    const hasOutgoingMention = /@[\w\u4e00-\u9fff]{1,20}/.test(body.trim());
+    if (msg.chatType === 'group' && hasOutgoingMention && adapter.getGroupMembers) {
       try {
         const memberCache = await adapter.getGroupMembers(msg.chatId);
         mentions = parseMentions(body.trim(), memberCache).mentions;


### PR DESCRIPTION
Fixes #57.

- skip guild member lookup when the reply has no @mention
- bound Discord member fetching to 2 seconds
- fall back to the existing member cache when fetching is unavailable

Tests: 194 gateway tests passed; `pnpm run build` passed.